### PR TITLE
Fix: Show fili adapter errors

### DIFF
--- a/packages/data/addon/adapters/facts/bard.ts
+++ b/packages/data/addon/adapters/facts/bard.ts
@@ -27,6 +27,10 @@ import { omit } from 'lodash-es';
 export type Query = RequestOptions & Dict<string | number | boolean>;
 export type AliasFn = (column: string) => string;
 
+export class FactAdapterError extends Error {
+  name = 'FactAdapterError';
+}
+
 /**
  * @function formatDimensionFieldName
  * @param field - dimension id
@@ -118,7 +122,7 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
   _buildDateTimeParam(request: RequestV2): string {
     const dateTimeFilters = request.filters.filter(isDateTime);
     if (dateTimeFilters.length !== 1) {
-      throw new Error(
+      throw new FactAdapterError(
         `Exactly one '${request.table}.dateTime' filter is supported, you have ${dateTimeFilters.length}`
       );
     }
@@ -126,7 +130,7 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
     const dateTime = request.columns.filter(isDateTime)[0];
     const timeGrain = dateTime?.parameters?.grain || 'all';
     if (timeGrain !== filter.parameters.grain) {
-      throw new Error(
+      throw new FactAdapterError(
         `The requested filter timeGrain '${filter.parameters.grain}', must match the column timeGrain '${timeGrain}'`
       );
     }
@@ -242,7 +246,7 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
 
     const dateTimeColumns = request.columns.filter(isDateTime);
     if (dateTimeColumns.length > 1) {
-      throw new Error(`Requsting more than one '${request.table}.dateTime' columns is not supported`);
+      throw new FactAdapterError(`Requsting more than one '${request.table}.dateTime' columns is not supported`);
     }
     let timeGrain = dateTimeColumns[0]?.parameters?.grain || 'all';
     timeGrain = 'isoWeek' === timeGrain ? 'week' : timeGrain;
@@ -406,6 +410,6 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
   }
 
   asyncFetchDataForRequest(_request: RequestV2, _options: RequestOptions): Promise<AsyncQueryResponse> {
-    throw new Error('Method not implemented.');
+    throw new FactAdapterError('Method not implemented.');
   }
 }

--- a/packages/data/addon/serializers/facts/bard.ts
+++ b/packages/data/addon/serializers/facts/bard.ts
@@ -12,6 +12,7 @@ import { canonicalizeMetric } from 'navi-data/utils/metric';
 import NaviFactResponse from 'navi-data/models/navi-fact-response';
 import NaviAdapterError, { NaviErrorDetails } from 'navi-data/errors/navi-adapter-error';
 import { AjaxError } from 'ember-ajax/errors';
+import { FactAdapterError } from 'navi-data/adapters/facts/bard';
 
 type BardError = {
   description: string;
@@ -103,6 +104,9 @@ export default class BardFactsSerializer extends EmberObject implements NaviFact
       } else {
         errorDetails.detail = this.normalizeErrorMessage(error.payload);
       }
+    } else if (error instanceof FactAdapterError) {
+      errorDetails.title = error.name;
+      errorDetails.detail = error.message;
     }
 
     return new NaviAdapterError('Bard Request Failed', [errorDetails], error);

--- a/packages/data/tests/unit/services/navi-facts-test.ts
+++ b/packages/data/tests/unit/services/navi-facts-test.ts
@@ -184,7 +184,7 @@ module('Unit | Service | Navi Facts', function(hooks) {
   });
 
   test('fetch and catch error', async function(assert) {
-    assert.expect(4);
+    assert.expect(6);
 
     // Return an error object
     Server.get(`${HOST}/v1/data/table1/grain1/d1/d2/`, () => {
@@ -214,6 +214,15 @@ module('Unit | Service | Navi Facts', function(hooks) {
     await Service.fetch(TestRequest).catch((response: NaviAdapterError) => {
       assert.ok(true, 'A request error falls into the promise catch block');
       assert.equal(response.details[0], 'Server Error', 'String error extracted');
+    });
+
+    await Service.fetch({ ...TestRequest, filters: [] }).catch((response: NaviAdapterError) => {
+      assert.ok(true, 'A request error falls into the promise catch block');
+      assert.equal(
+        response.details[0],
+        `Exactly one 'table1.dateTime' filter is supported, you have 0`,
+        'Adapter error is shown'
+      );
     });
   });
 


### PR DESCRIPTION
## Description
Our new error handling/extraction does not surface errors thrown from the adapter such as requiring a filter (which can happen since we don't have required table filters)

## Proposed Changes
- add a check to see if error was thrown from adapter

## Screenshots
![adapter errors](https://user-images.githubusercontent.com/12093492/102274971-54265600-3eea-11eb-8f9b-0a8a720fbe2a.png)

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
