### PR TITLE
Update: Fix Navi Report minus filters expanding

### DIFF
--- a/packages/core/addon/models/bard-request-v2/request.ts
+++ b/packages/core/addon/models/bard-request-v2/request.ts
@@ -56,7 +56,7 @@ const Validations = buildValidations({
       message: 'At least one column should be selected'
     })
   ],
-  table: validator('presence', {
+  tableMetadata: validator('presence', {
     presence: true,
     message: 'Table is invalid or unavailable'
   }),

--- a/packages/dashboards/addon/templates/dashboards/dashboard/widgets/widget.hbs
+++ b/packages/dashboards/addon/templates/dashboards/dashboard/widgets/widget.hbs
@@ -53,18 +53,20 @@
 
       <li class="navi-report-widget__action">
         {{!-- Export action is only enabled when request is valid --}}
-        {{#let (component (concat "report-actions/" (unless (is-empty (feature-flag "exportFileTypes")) "multiple-format-export" "export"))) as |ExportAction|}}
-          <ExportAction
-            class="navi-report-widget__action-link {{unless @model.validations.isTruelyValid "navi-report-widget__action-link--is-disabled"}}"
-            @report={{@model}}
-            @disabled={{not @model.validations.isTruelyValid}}
-          >
-            <NaviIcon @icon="download" class="navi-report-widget__icon" />
-            Export
-            <EmberTooltip>
-              {{if @model.validations.isTruelyValid "Export the report" "Run a valid report to enable export"}}
-            </EmberTooltip>
-          </ExportAction>
+        {{#let (feature-flag "exportFileTypes") as |exportFileTypes|}}
+          {{#let (component (concat "report-actions/" (if (gt exportFileTypes.length 1) "multiple-format-export" "export"))) as |ExportAction|}}
+            <ExportAction
+              class="navi-report-widget__action-link {{unless @model.validations.isTruelyValid "navi-report-widget__action-link--is-disabled"}}"
+              @report={{@model}}
+              @disabled={{not @model.validations.isTruelyValid}}
+            >
+              <NaviIcon @icon="download" class="navi-report-widget__icon" />
+              Export
+              <EmberTooltip>
+                {{if @model.validations.isTruelyValid "Export the report" "Run a valid report to enable export"}}
+              </EmberTooltip>
+            </ExportAction>
+          {{/let}}
         {{/let}}
       </li>
 

--- a/packages/data/addon/mirage/fixtures/bard-meta-dimensions.js
+++ b/packages/data/addon/mirage/fixtures/bard-meta-dimensions.js
@@ -259,7 +259,7 @@ export default {
       category: 'test',
       datatype: 'text',
       storageStrategy: 'loaded',
-      fields: defaultFields
+      fields: [defaultFields[0]]
     },
     {
       name: 'Budget',

--- a/packages/reports/addon/components/filter-collection.ts
+++ b/packages/reports/addon/components/filter-collection.ts
@@ -11,7 +11,7 @@ import { dasherize } from '@ember/string';
 interface FilterCollectionArgs {
   isCollapsed: boolean;
   request: RequestFragment;
-  onUpdateCollapsed(isCollapsed: boolean): void;
+  onUpdateCollapsed?: (isCollapsed: boolean) => void;
   onRemoveFilter(filter: FilterFragment): void;
   onUpdateFilter(filter: FilterFragment): void;
 }

--- a/packages/reports/addon/components/navi-column-config.hbs
+++ b/packages/reports/addon/components/navi-column-config.hbs
@@ -14,7 +14,7 @@
             @onOpenColumn={{this.openColumn}}
             @onRemoveColumn={{fn @onRemoveColumn column.fragment}}
             @cloneColumn={{fn this.cloneColumn column}}
-            @toggleColumnFilter={{fn @onToggleFilter column.fragment}}
+            @toggleColumnFilter={{fn this.onToggleFilter column.fragment}}
             @onRenameColumn={{fn @onRenameColumn column.fragment}}
             @onUpdateColumnParam={{fn @onUpdateColumnParam column.fragment}}
           />

--- a/packages/reports/addon/components/navi-column-config.ts
+++ b/packages/reports/addon/components/navi-column-config.ts
@@ -66,7 +66,6 @@ export default class NaviColumnConfig extends Component<NaviColumnConfigArgs> {
 
   /**
    * Adds a copy of the given column to the request including its parameters
-   * @action
    * @param column - The metric/dimension column to make a copy of
    */
   @action
@@ -76,7 +75,6 @@ export default class NaviColumnConfig extends Component<NaviColumnConfigArgs> {
   }
 
   /**
-   * @action
    * @param column - the column fragment to be renamed
    * @param index - the new name for the column
    */
@@ -87,12 +85,27 @@ export default class NaviColumnConfig extends Component<NaviColumnConfigArgs> {
 
   /**
    * Opens a column
-   * @action
    * @param column - The column to open
    */
   @action
   openColumn(column: ConfigColumn) {
     this.currentlyOpenColumn = column;
+  }
+
+  /**
+   * Toggles a filter
+   * @param column - The column to open
+   */
+  @action
+  onToggleFilter(column: ColumnFragment) {
+    const { request } = this.args.report;
+    const previousFilters = request.filters.length;
+    this.args.onToggleFilter(column);
+    const newFilters = request.filters.length;
+    // TODO: should be done a level higher
+    if (newFilters > previousFilters) {
+      this.args.openFilters();
+    }
   }
 
   /**

--- a/packages/reports/addon/templates/components/navi-action-list.hbs
+++ b/packages/reports/addon/templates/components/navi-action-list.hbs
@@ -23,18 +23,20 @@
 
   <li class="action">
   {{!-- Export only enabled on a validated report --}}
-    {{#let (component (concat "report-actions/" (unless (is-empty (feature-flag "exportFileTypes")) "multiple-format-export" "export"))) as |ExportAction|}}
-      <ExportAction
-        id={{concat "navi-report-action-export-" @index}}
-        class="navi-reports-index__report-control export {{unless @item.request.validations.isTruelyValid "navi-report__action-link--force-disabled"}}"
-        @report={{@item}}
-        @disabled={{not @item.request.validations.isTruelyValid}}
-      >
-        <NaviIcon @icon="download" />
-        <EmberTooltip @popperContainer="body" @targetId={{concat "navi-report-action-export-" @index}}>
-          {{if @item.request.validations.isTruelyValid "Export the report" "Run a valid report to enable export"}}
-        </EmberTooltip>
-      </ExportAction>
+    {{#let (feature-flag "exportFileTypes") as |exportFileTypes|}}
+      {{#let (component (concat "report-actions/" (if (gt exportFileTypes.length 1) "multiple-format-export" "export"))) as |ExportAction|}}
+        <ExportAction
+          id={{concat "navi-report-action-export-" @index}}
+          class="navi-reports-index__report-control export {{unless @item.request.validations.isTruelyValid "navi-report__action-link--force-disabled"}}"
+          @report={{@item}}
+          @disabled={{not @item.request.validations.isTruelyValid}}
+        >
+          <NaviIcon @icon="download" />
+          <EmberTooltip @popperContainer="body" @targetId={{concat "navi-report-action-export-" @index}}>
+            {{if @item.request.validations.isTruelyValid "Export the report" "Run a valid report to enable export"}}
+          </EmberTooltip>
+        </ExportAction>
+      {{/let}}
     {{/let}}
   </li>
 

--- a/packages/reports/addon/templates/components/report-actions.hbs
+++ b/packages/reports/addon/templates/components/report-actions.hbs
@@ -47,15 +47,17 @@
 {{!-- Export only enabled on a valid report --}}
 {{#if (feature-flag "exportFileTypes")}}
   <li class="navi-report__action">
-    {{#let (component (concat "report-actions/" (unless (is-empty (feature-flag "exportFileTypes")) "multiple-format-export" "export"))) as |ExportAction|}}
-      <ExportAction
-        class="navi-report__action-link {{unless @model.validations.isTruelyValid "navi-report__action-link--force-disabled"}}"
-        @report={{@model}}
-        @disabled={{not @model.validations.isTruelyValid}}
-      >
-        <NaviIcon @icon="download" class="navi-report__action-icon" />
-        Export
-      </ExportAction>
+    {{#let (feature-flag "exportFileTypes") as |exportFileTypes|}}
+      {{#let (component (concat "report-actions/" (if (gt exportFileTypes.length 1) "multiple-format-export" "export"))) as |ExportAction|}}
+        <ExportAction
+          class="navi-report__action-link {{unless @model.validations.isTruelyValid "navi-report__action-link--force-disabled"}}"
+          @report={{@model}}
+          @disabled={{not @model.validations.isTruelyValid}}
+        >
+          <NaviIcon @icon="download" class="navi-report__action-icon" />
+          Export
+        </ExportAction>
+      {{/let}}
     {{/let}}
     <EmberTooltip>
       {{if @model.request.validations.isTruelyValid "Export the report" "Run a valid report to enable export"}}


### PR DESCRIPTION
## Description
Fixes most failing tests from Navi Report

## Proposed Changes
- Fixed an issue with export types not working as expected
- Fixed an issue with missing table's not being handled the same

Still need to fix `filters - collapse and expand` which I'm planning to handle in a similar way to our `DID_ADD_COLUMN` consumer

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
