### PR TITLE
Fix: Lookback for isoWeek, better fili grain support

### DIFF
--- a/packages/core/tests/dummy/config/environment.js
+++ b/packages/core/tests/dummy/config/environment.js
@@ -37,7 +37,7 @@ module.exports = function(environment) {
       },
       predefinedIntervalRanges: {
         day: ['P1D', 'P7D', 'P14D', 'P30D', 'P60D', 'P90D', 'P180D', 'P400D'],
-        week: ['P1W', 'P4W', 'P8W', 'P13W', 'P26W', 'P52W', 'P78W', 'P104W'],
+        isoWeek: ['P1W', 'P4W', 'P8W', 'P13W', 'P26W', 'P52W', 'P78W', 'P104W'],
         month: ['P1M', 'P3M', 'P6M', 'P12M', 'P18M', 'P24M'],
         quarter: ['P3M', 'P6M', 'P12M', 'P24M'],
         year: ['P1Y', 'P2Y']

--- a/packages/data/addon/utils/classes/duration.ts
+++ b/packages/data/addon/utils/classes/duration.ts
@@ -10,10 +10,10 @@ import { assert } from '@ember/debug';
  * Enum for supported date units
  * @enum {String}
  */
-type DateUnit = 'day' | 'isoWeek' | 'month' | 'year';
+type DateUnit = 'day' | 'week' | 'month' | 'year';
 const DATE_UNITS: Record<string, DateUnit | undefined> = {
   D: 'day',
-  W: 'isoWeek',
+  W: 'week',
   M: 'month',
   Y: 'year'
 };

--- a/packages/data/addon/utils/classes/duration.ts
+++ b/packages/data/addon/utils/classes/duration.ts
@@ -10,10 +10,10 @@ import { assert } from '@ember/debug';
  * Enum for supported date units
  * @enum {String}
  */
-type DateUnit = 'day' | 'week' | 'month' | 'year';
+type DateUnit = 'day' | 'isoWeek' | 'month' | 'year';
 const DATE_UNITS: Record<string, DateUnit | undefined> = {
   D: 'day',
-  W: 'week',
+  W: 'isoWeek',
   M: 'month',
   Y: 'year'
 };

--- a/packages/data/addon/utils/duration-utils.ts
+++ b/packages/data/addon/utils/duration-utils.ts
@@ -6,7 +6,7 @@
 import { assert } from '@ember/debug';
 import moment, { Moment } from 'moment';
 import Duration from './classes/duration';
-import { DateTimePeriod, getFirstDayEpochForGrain } from './date';
+import { DateTimePeriod, getFirstDayEpochForGrain, getPeriodForGrain } from './date';
 
 /**
  * Map of durations equivalent to a year for different time units
@@ -41,9 +41,10 @@ export default {
     const value = duration.getValue();
     const unit = duration.getUnit();
     assert('The duration unit must be defined', unit);
+    const period = getPeriodForGrain(unit);
     assert('The duration has a number value of units', typeof value === 'number');
     // Moment subtract mutates original date object hence the clone
-    return date.clone().subtract(value, unit);
+    return date.clone().subtract(value, period);
   },
 
   /**

--- a/packages/reports/addon/components/filter-builders/time-dimension.ts
+++ b/packages/reports/addon/components/filter-builders/time-dimension.ts
@@ -127,7 +127,6 @@ export function valuesForOperator(
 }
 
 export function internalOperatorForValues(filter: FilterFragment): InternalOperatorType {
-  debugger;
   const { values, operator } = filter;
   const [startStr, endStr] = values as string[];
 
@@ -153,7 +152,7 @@ export function internalOperatorForValues(filter: FilterFragment): InternalOpera
   } else if (
     lookbackDuration &&
     lookbackGrain &&
-    ['day', 'isoWeek', 'month', 'year'].includes(lookbackGrain) &&
+    ['day', 'week', 'month', 'year'].includes(lookbackGrain) &&
     end === 'current'
   ) {
     internalId = OPERATORS.lookback;

--- a/packages/reports/addon/components/filter-builders/time-dimension.ts
+++ b/packages/reports/addon/components/filter-builders/time-dimension.ts
@@ -7,7 +7,7 @@ import { assert, warn } from '@ember/debug';
 import { action, computed } from '@ember/object';
 import { capitalize } from '@ember/string';
 import moment from 'moment';
-import FilterFragment from 'navi-core/addon/models/bard-request-v2/fragments/filter';
+import FilterFragment from 'navi-core/models/bard-request-v2/fragments/filter';
 import { parseDuration } from 'navi-data/utils/classes/duration';
 import { DateTimePeriod, getPeriodForGrain, Grain } from 'navi-data/utils/date';
 import Interval from 'navi-data/utils/classes/interval';
@@ -38,7 +38,7 @@ type TimeDimensionFilterArgs = BaseFilterBuilderComponent['args'] & {
  * @param grain - the grain to turn into a period
  */
 type DateGrain = Exclude<DateTimePeriod, 'second' | 'minute' | 'hour'>;
-function intervalPeriodForGrain(grain: Grain): DateGrain {
+export function intervalPeriodForGrain(grain: Grain): DateGrain {
   if (grain === 'quarter') {
     return 'month';
   }
@@ -51,6 +51,124 @@ function intervalPeriodForGrain(grain: Grain): DateGrain {
   return period;
 }
 
+/**
+ * Converts an Interval to a format suitable to the newOperator while retaining as much information as possible
+ * e.g. ([P7D, current], day, in) -> [2020-01-01,2020-01-08]
+ * @param prevValues - the previous filter values
+ * @param dateTimePeriod - the time period being requested
+ * @param newOperator - the operator to build values for
+ */
+export function valuesForOperator(
+  filter: FilterFragment,
+  dateTimePeriod: Grain,
+  newOperator?: InternalOperatorType
+): TimeFilterValues {
+  newOperator = newOperator || internalOperatorForValues(filter);
+  const prevValues = filter.values as TimeFilterValues;
+  const startStr = prevValues[0] || 'P1D';
+  let endStr = prevValues[1];
+  if (!endStr) {
+    endStr = 'current';
+  }
+
+  if (newOperator === OPERATORS.current) {
+    return ['current', 'next'];
+  } else if (newOperator === OPERATORS.lookback) {
+    const interval = Interval.parseFromStrings(startStr, endStr);
+    const end = interval.asMomentsForTimePeriod(dateTimePeriod).end.utc(true);
+    let intervalTimePeriod = intervalPeriodForGrain(dateTimePeriod);
+    const nonAllGrain = dateTimePeriod === 'all' ? 'day' : dateTimePeriod;
+
+    let intervalValue;
+    if (
+      end.isSame(
+        moment()
+          .startOf(nonAllGrain)
+          .utc(true)
+      )
+    ) {
+      // end is 'current', get lookback amount
+      intervalValue = interval.diffForTimePeriod(intervalTimePeriod);
+    } else {
+      intervalValue = 1;
+    }
+
+    if (dateTimePeriod === 'quarter') {
+      // round to quarter
+      const quarters = Math.max(Math.floor(intervalValue / MONTHS_IN_QUARTER), 1);
+      intervalValue = quarters * MONTHS_IN_QUARTER;
+    }
+
+    const dateTimePeriodLabel = intervalTimePeriod[0].toUpperCase();
+    return [`P${intervalValue}${dateTimePeriodLabel}`, 'current'];
+  } else if (newOperator === OPERATORS.since) {
+    const interval = Interval.parseFromStrings(startStr, endStr);
+    const { start } = interval.asMomentsForTimePeriod(dateTimePeriod);
+    return [start.utc(true).toISOString()];
+  } else if (newOperator === OPERATORS.before) {
+    const interval = Interval.parseFromStrings(startStr, endStr);
+    const { end } = interval.asMomentsForTimePeriod(dateTimePeriod);
+    return [
+      end
+        .utc(true)
+        .subtract(1, getPeriodForGrain(dateTimePeriod))
+        .toISOString()
+    ];
+  } else if (newOperator === OPERATORS.dateRange) {
+    const interval = Interval.parseFromStrings(startStr, endStr);
+    const { start, end } = interval.asMomentsForTimePeriod(dateTimePeriod);
+    return [start.utc(true).toISOString(), end.utc(true).toISOString()];
+  }
+  warn(`No operator was found for the values '${prevValues.join(',')}'`, {
+    id: 'time-dimension-filter-builder-no-operator'
+  });
+
+  return [];
+}
+
+export function internalOperatorForValues(filter: FilterFragment): InternalOperatorType {
+  debugger;
+  const { values, operator } = filter;
+  const [startStr, endStr] = values as string[];
+
+  if (!startStr && !endStr && operator === 'bet') {
+    // there's no values
+    return OPERATORS.dateRange;
+  } else if (!(startStr && endStr)) {
+    // there's only one value
+    if (operator === 'gte') {
+      return OPERATORS.since;
+    } else if (operator === 'lte') {
+      return OPERATORS.before;
+    }
+  }
+
+  const interval = Interval.parseFromStrings(startStr, endStr);
+  const { start, end } = interval.asStrings();
+  const [lookbackDuration, lookbackGrain] = parseDuration(start) || [];
+
+  let internalId: InternalOperatorType;
+  if (start === 'current' && end === 'next') {
+    internalId = OPERATORS.current;
+  } else if (
+    lookbackDuration &&
+    lookbackGrain &&
+    ['day', 'isoWeek', 'month', 'year'].includes(lookbackGrain) &&
+    end === 'current'
+  ) {
+    internalId = OPERATORS.lookback;
+  } else if (moment.isMoment(interval['_start']) && end === 'current') {
+    internalId = OPERATORS.since;
+  } else if (moment.isMoment(interval['_start']) && moment.isMoment(interval['_end'])) {
+    internalId = OPERATORS.dateRange;
+  } else {
+    internalId = OPERATORS.dateRange;
+  }
+
+  assert(`A component for ${operator} [${values.join(',')}] exists`, internalId);
+  return internalId;
+}
+
 export default class TimeDimensionFilterBuilder extends BaseFilterBuilderComponent<TimeDimensionFilterArgs> {
   @computed('args.filter.parameters.grain')
   get timeGrainName() {
@@ -58,7 +176,7 @@ export default class TimeDimensionFilterBuilder extends BaseFilterBuilderCompone
   }
 
   /**
-   * list of valid operators for a date-time filter
+   * list of valid operators for a time-dimension filter
    */
   @computed('args.filter.parameters.grain', 'timeGrainName')
   get supportedOperators(): InteralFilterBuilderOperators[] {
@@ -97,112 +215,15 @@ export default class TimeDimensionFilterBuilder extends BaseFilterBuilderCompone
   }
 
   /**
-   * Converts an Interval to a format suitable to the newOperator while retaining as much information as possible
-   * e.g. ([P7D, current], day, in) -> [2020-01-01,2020-01-08]
-   * @param prevValues - the previous filter values
-   * @param dateTimePeriod - the time period being requested
-   * @param newOperator - the operator to build values for
-   */
-  valuesForOperator(prevValues: TimeFilterValues, dateTimePeriod: Grain, newOperator: InternalOperatorType) {
-    const startStr = prevValues[0] || 'P1D';
-    let endStr = prevValues[1];
-    if (!endStr) {
-      endStr = 'current';
-    }
-
-    if (newOperator === OPERATORS.current) {
-      return ['current', 'next'];
-    } else if (newOperator === OPERATORS.lookback) {
-      const interval = Interval.parseFromStrings(startStr, endStr);
-      const end = interval.asMomentsForTimePeriod(dateTimePeriod).end.utc(true);
-      let intervalTimePeriod = intervalPeriodForGrain(dateTimePeriod);
-      const nonAllGrain = dateTimePeriod === 'all' ? 'day' : dateTimePeriod;
-
-      let intervalValue;
-      if (
-        end.isSame(
-          moment()
-            .startOf(nonAllGrain)
-            .utc(true)
-        )
-      ) {
-        // end is 'current', get lookback amount
-        intervalValue = interval.diffForTimePeriod(intervalTimePeriod);
-      } else {
-        intervalValue = 1;
-      }
-
-      if (dateTimePeriod === 'quarter') {
-        // round to quarter
-        const quarters = Math.max(Math.floor(intervalValue / MONTHS_IN_QUARTER), 1);
-        intervalValue = quarters * MONTHS_IN_QUARTER;
-      }
-
-      const dateTimePeriodLabel = intervalTimePeriod[0].toUpperCase();
-      return [`P${intervalValue}${dateTimePeriodLabel}`, 'current'];
-    } else if (newOperator === OPERATORS.since) {
-      const interval = Interval.parseFromStrings(startStr, endStr);
-      const { start } = interval.asMomentsForTimePeriod(dateTimePeriod);
-      return [start.utc(true).toISOString()];
-    } else if (newOperator === OPERATORS.before) {
-      const interval = Interval.parseFromStrings(startStr, endStr);
-      const { end } = interval.asMomentsForTimePeriod(dateTimePeriod);
-      return [
-        end
-          .utc(true)
-          .subtract(1, getPeriodForGrain(dateTimePeriod))
-          .toISOString()
-      ];
-    } else if (newOperator === OPERATORS.dateRange) {
-      const interval = Interval.parseFromStrings(startStr, endStr);
-      const { start, end } = interval.asMomentsForTimePeriod(dateTimePeriod);
-      return [start.utc(true).toISOString(), end.utc(true).toISOString()];
-    }
-    warn(`No operator was found for the values '${prevValues.join(',')}'`, {
-      id: 'time-dimension-filter-builder-no-operator'
-    });
-
-    return [];
-  }
-
-  /**
    * Finds the appropriate interval operator to modify an existing interval
-   * @param interval - the interval to choose an operator for
    * @returns the best supported operator for this interval
    */
   @computed('args.filter.{values,operator}', 'supportedOperators')
   get selectedOperator(): InteralFilterBuilderOperators {
-    const { values, operator } = this.args.filter;
-    const [startStr, endStr] = values;
-    if (!(startStr && endStr)) {
-      const filterValueBuilder = this.supportedOperators.find(({ id }) => id === operator);
-      assert(`A filter value component for ${operator} operator exists`, filterValueBuilder);
-      return filterValueBuilder;
-    }
-    const interval = Interval.parseFromStrings(startStr, endStr);
-    const { start, end } = interval.asStrings();
-
-    const [lookbackDuration, lookbackGrain] = parseDuration(start) || [];
-    let operatorId: InternalOperatorType;
-    if (start === 'current' && end === 'next') {
-      operatorId = OPERATORS.current;
-    } else if (
-      lookbackDuration &&
-      lookbackGrain &&
-      ['day', 'week', 'month', 'year'].includes(lookbackGrain) &&
-      end === 'current'
-    ) {
-      operatorId = OPERATORS.lookback;
-    } else if (moment.isMoment(interval['_start']) && end === 'current') {
-      operatorId = OPERATORS.since;
-    } else if (moment.isMoment(interval['_start']) && moment.isMoment(interval['_end'])) {
-      operatorId = OPERATORS.dateRange;
-    } else {
-      operatorId = OPERATORS.dateRange;
-    }
+    const operatorId = internalOperatorForValues(this.args.filter);
 
     const filterValueBuilder = this.supportedOperators.find(({ internalId }) => internalId === operatorId);
-    assert(`A filter value component for ${operator} operator exists`, filterValueBuilder);
+    assert(`A filter value component for ${operatorId} operator exists`, filterValueBuilder);
     return filterValueBuilder;
   }
 
@@ -217,12 +238,10 @@ export default class TimeDimensionFilterBuilder extends BaseFilterBuilderCompone
       return;
     }
 
-    const {
-      parameters: { grain },
-      values
-    } = this.args.filter;
+    const { filter } = this.args;
+    const { grain } = filter.parameters;
 
-    const newInterval = this.valuesForOperator(values as TimeFilterValues, grain as Grain, operator.internalId);
+    const newInterval = valuesForOperator(filter, grain as Grain, operator.internalId);
 
     this.args.onUpdateFilter({
       operator: operator.id,

--- a/packages/reports/addon/components/filter-values/time-dimension/lookback.ts
+++ b/packages/reports/addon/components/filter-values/time-dimension/lookback.ts
@@ -14,7 +14,7 @@ import { computed, action } from '@ember/object';
 import Duration from 'navi-data/utils/classes/duration';
 import Interval from 'navi-data/utils/classes/interval';
 import { isEmpty } from '@ember/utils';
-import { MONTHS_IN_QUARTER } from '../../filter-builders/time-dimension';
+import { intervalPeriodForGrain, MONTHS_IN_QUARTER } from '../../filter-builders/time-dimension';
 import config from 'ember-get-config';
 import { capitalize } from '@ember/string';
 import { Grain } from 'navi-data/utils/date';
@@ -46,12 +46,9 @@ export default class LookbackInput extends BaseIntervalComponent {
   lookbackToDuration(amount: number, dateTimePeriod: Grain): string {
     if (dateTimePeriod === 'quarter') {
       amount = amount * MONTHS_IN_QUARTER;
-      dateTimePeriod = 'month';
     }
-    if (dateTimePeriod === 'hour') {
-      dateTimePeriod = 'day';
-    }
-    return `P${amount}${dateTimePeriod[0].toUpperCase()}`;
+    const period = intervalPeriodForGrain(dateTimePeriod);
+    return `P${amount}${period[0].toUpperCase()}`;
   }
 
   /**

--- a/packages/reports/addon/consumers/request/fili.ts
+++ b/packages/reports/addon/consumers/request/fili.ts
@@ -9,8 +9,10 @@ import RequestActionDispatcher, { RequestActions } from 'navi-reports/services/r
 import ColumnFragment from 'navi-core/models/bard-request-v2/fragments/column';
 import ReportModel from 'navi-core/models/report';
 import { getDataSource } from 'navi-data/utils/adapter';
-import DimensionMetadataModel from 'navi-data/addon/models/metadata/dimension';
+import DimensionMetadataModel from 'navi-data/models/metadata/dimension';
 import { Parameters } from 'navi-data/adapters/facts/interface';
+import { valuesForOperator } from 'navi-reports/components/filter-builders/time-dimension';
+import { Grain } from 'navi-data/utils/date';
 
 export default class FiliConsumer extends ActionConsumer {
   @service requestActionDispatcher!: RequestActionDispatcher;
@@ -46,7 +48,8 @@ export default class FiliConsumer extends ActionConsumer {
 
       const { timeGrainColumn, dateTimeFilter } = request;
       if (timeGrainColumn === columnFragment && parameterKey === 'grain' && dateTimeFilter) {
-        const changeset = { parameters: { ...dateTimeFilter.parameters, [parameterKey]: parameterValue } };
+        const values = valuesForOperator(dateTimeFilter, parameterValue as Grain);
+        const changeset = { parameters: { ...dateTimeFilter.parameters, [parameterKey]: parameterValue }, values };
         this.requestActionDispatcher.dispatch(RequestActions.UPDATE_FILTER, route, dateTimeFilter, changeset);
       }
     },

--- a/packages/reports/addon/helpers/format-interval-inclusive-inclusive.js
+++ b/packages/reports/addon/helpers/format-interval-inclusive-inclusive.js
@@ -1,11 +1,12 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import { helper as buildHelper } from '@ember/component/helper';
 import { assert } from '@ember/debug';
 import { capitalize } from '@ember/string';
 import Duration from 'navi-data/utils/classes/duration';
+import { getPeriodForGrain } from 'navi-data/utils/date';
 
 /**
  * Converts a duration into string representing how long ago duration is from today
@@ -37,13 +38,15 @@ export function formatDurationFromCurrent(duration, timePeriod) {
     assert('Formatting hour the same way as we do day', durationUnit === 'day');
   }
 
+  const period = getPeriodForGrain(durationUnit);
+
   // Singular
   if (durationValue === 1) {
-    return `Last ${capitalize(durationUnit)}`;
+    return `Last ${capitalize(period)}`;
   }
 
   // Standard case
-  return `Last ${durationValue} ${capitalize(durationUnit)}s`;
+  return `Last ${durationValue} ${capitalize(period)}s`;
 }
 
 /**

--- a/packages/reports/config/environment.js
+++ b/packages/reports/config/environment.js
@@ -9,7 +9,8 @@ module.exports = function(/* environment, appConfig */) {
       predefinedIntervalRanges: {
         hour: ['P1D', 'P7D', 'P14D', 'P30D'],
         day: ['P1D', 'P7D', 'P14D', 'P30D', 'P60D', 'P90D', 'P180D', 'P400D'],
-        week: ['P1W', 'P4W', 'P8W', 'P13W', 'P26W', 'P52W', 'P78W', 'P104W'],
+        //TODO: Better 'week' support
+        isoWeek: ['P1W', 'P4W', 'P8W', 'P13W', 'P26W', 'P52W', 'P78W', 'P104W'],
         month: ['P1M', 'P3M', 'P6M', 'P12M', 'P18M', 'P24M'],
         quarter: ['P3M', 'P6M', 'P12M', 'P24M'],
         year: ['P1Y', 'P2Y']

--- a/packages/reports/tests/unit/components/filter-builders/time-dimension-test.ts
+++ b/packages/reports/tests/unit/components/filter-builders/time-dimension-test.ts
@@ -4,7 +4,7 @@ import Interval from 'navi-data/utils/classes/interval';
 import { set } from '@ember/object';
 //@ts-ignore
 import { createGlimmerComponent } from 'navi-core/test-support';
-import TimeDimensionFilterBuilder from 'navi-reports/components/filter-builders/time-dimension';
+import TimeDimensionFilterBuilder, { valuesForOperator } from 'navi-reports/components/filter-builders/time-dimension';
 import StoreService from '@ember-data/store';
 import { TestContext } from 'ember-test-helpers';
 import RequestFragment from 'navi-core/models/bard-request-v2/request';
@@ -115,42 +115,40 @@ module('Unit | Component | filter-builders/time-dimension', function(hooks) {
 
   test('Switching operator', function(assert) {
     const filter = Request.filters.objectAt(0) as TimeDimensionFilterBuilder['args']['filter'];
-    filter.values = ['P1W', 'current'];
     filter.updateParameters({ grain: 'isoWeek' });
-    const args: TimeDimensionFilterBuilder['args'] = {
-      request: Request,
-      filter,
-      onUpdateFilter: () => undefined
-    };
-
-    let dateBuilder = createGlimmerComponent(
-      'component:filter-builders/time-dimension',
-      args
-    ) as TimeDimensionFilterBuilder;
 
     // 'current' tests
+    filter.values = ['P1W', 'current'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['P7D', 'current'], 'day', 'current'),
+      valuesForOperator(filter, 'day', 'current'),
       ['current', 'next'],
       'Switching to current day is current/next'
     );
+
+    filter.values = ['2019-01-01', '2019-01-02'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['2019-01-01', '2019-01-02'], 'isoWeek', 'current'),
+      valuesForOperator(filter, 'isoWeek', 'current'),
       ['current', 'next'],
       'Switching to current isoWeek is current/next'
     );
+
+    filter.values = ['P1M', '2019-01-01'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['P1M', '2019-01-01'], 'month', 'current'),
+      valuesForOperator(filter, 'month', 'current'),
       ['current', 'next'],
       'Switching to current month is current/next'
     );
+
+    filter.values = ['P6M', 'current'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['P6M', 'current'], 'quarter', 'current'),
+      valuesForOperator(filter, 'quarter', 'current'),
       ['current', 'next'],
       'Switching to current quarter is current/next'
     );
+
+    filter.values = ['2018-01-01', '2019-01-01'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['2018-01-01', '2019-01-01'], 'year', 'current'),
+      valuesForOperator(filter, 'year', 'current'),
       ['current', 'next'],
       'Switching to current year is current/next'
     );
@@ -160,53 +158,72 @@ module('Unit | Component | filter-builders/time-dimension', function(hooks) {
       return [start.utc(true).toISOString(), end.utc(true).toISOString()];
     };
     // 'inPast' tests
+    filter.values = intervalFor('P4D', 'day');
     assert.deepEqual(
-      dateBuilder.valuesForOperator(intervalFor('P4D', 'day'), 'day', 'inPast'),
+      valuesForOperator(filter, 'day', 'inPast'),
       ['P4D', 'current'],
       'Switching to inPast counts the days'
     );
+
+    filter.values = intervalFor('P3W', 'isoWeek');
     assert.deepEqual(
-      dateBuilder.valuesForOperator(intervalFor('P3W', 'isoWeek'), 'isoWeek', 'inPast'),
+      valuesForOperator(filter, 'isoWeek', 'inPast'),
       ['P3W', 'current'],
       'Switching to inPast counts the isoWeek'
     );
+
+    filter.values = intervalFor('P6M', 'month');
     assert.deepEqual(
-      dateBuilder.valuesForOperator(intervalFor('P6M', 'month'), 'month', 'inPast'),
+      valuesForOperator(filter, 'month', 'inPast'),
       ['P6M', 'current'],
       'Switching to inPast counts the months'
     );
+
+    filter.values = intervalFor('P9M', 'quarter');
     assert.deepEqual(
-      dateBuilder.valuesForOperator(intervalFor('P9M', 'quarter'), 'quarter', 'inPast'),
+      valuesForOperator(filter, 'quarter', 'inPast'),
       ['P9M', 'current'],
       'Switching to inPast counts the quarters'
     );
+
+    filter.values = intervalFor('P2Y', 'year');
     assert.deepEqual(
-      dateBuilder.valuesForOperator(intervalFor('P2Y', 'year'), 'year', 'inPast'),
+      valuesForOperator(filter, 'year', 'inPast'),
       ['P2Y', 'current'],
       'Switching to inPast counts the years'
     );
+
+    filter.values = ['2019-01-01', '2019-01-02'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['2019-01-01', '2019-01-02'], 'day', 'inPast'),
+      valuesForOperator(filter, 'day', 'inPast'),
       ['P1D', 'current'],
       'inPast maps invalid interval to P1D/current for day'
     );
+
+    filter.values = ['2019-01-01', '2019-01-08'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['2019-01-01', '2019-01-08'], 'isoWeek', 'inPast'),
+      valuesForOperator(filter, 'isoWeek', 'inPast'),
       ['P1W', 'current'],
       'inPast maps invalid interval to P1W/current for day'
     );
+
+    filter.values = ['2019-01-01', '2019-03-03'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['2019-01-01', '2019-03-03'], 'month', 'inPast'),
+      valuesForOperator(filter, 'month', 'inPast'),
       ['P1M', 'current'],
       'inPast maps invalid interval to P1M/current for day'
     );
+
+    filter.values = ['2019-01-01', '2019-05-01'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['2019-01-01', '2019-05-01'], 'quarter', 'inPast'),
+      valuesForOperator(filter, 'quarter', 'inPast'),
       ['P3M', 'current'],
       'inPast maps invalid interval to P3M/current for day'
     );
+
+    filter.values = ['2019-01-01', '2020-03-02'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['2019-01-01', '2020-03-02'], 'year', 'inPast'),
+      valuesForOperator(filter, 'year', 'inPast'),
       ['P1Y', 'current'],
       'inPast maps invalid interval to P1Y/current for day'
     );
@@ -216,115 +233,159 @@ module('Unit | Component | filter-builders/time-dimension', function(hooks) {
       return [start.utc(true).toISOString(), end.utc(true).toISOString()];
     };
     // 'in' tests
+
+    filter.values = ['current', 'next'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['current', 'next'], 'day', 'in'),
+      valuesForOperator(filter, 'day', 'in'),
       currentInterval('day'),
       'in translates current/next to days for day'
     );
+
+    filter.values = ['current', 'next'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['current', 'next'], 'isoWeek', 'in'),
+      valuesForOperator(filter, 'isoWeek', 'in'),
       currentInterval('isoWeek'),
       'in translates current/next to days for isoWeek'
     );
+
+    filter.values = ['current', 'next'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['current', 'next'], 'month', 'in'),
+      valuesForOperator(filter, 'month', 'in'),
       currentInterval('month'),
       'in translates current/next to days for month'
     );
+
+    filter.values = ['current', 'next'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['current', 'next'], 'year', 'in'),
+      valuesForOperator(filter, 'year', 'in'),
       currentInterval('year'),
       'in translates current/next to days for year'
     );
+
+    filter.values = ['P1D', '2019-01-01'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['P1D', '2019-01-01'], 'day', 'in'),
+      valuesForOperator(filter, 'day', 'in'),
       ['2018-12-31T00:00:00.000Z', '2019-01-01T00:00:00.000Z'],
       'in translates P1D lookback to concrete'
     );
+
+    filter.values = ['P1W', '2019-01-01'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['P1W', '2019-01-01'], 'day', 'in'),
+      valuesForOperator(filter, 'day', 'in'),
       ['2018-12-25T00:00:00.000Z', '2019-01-01T00:00:00.000Z'],
       'in translates P1W lookback to concrete'
     );
+
+    filter.values = ['P1M', '2019-01-01'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['P1M', '2019-01-01'], 'day', 'in'),
+      valuesForOperator(filter, 'day', 'in'),
       ['2018-12-01T00:00:00.000Z', '2019-01-01T00:00:00.000Z'],
       'in translates P1M lookback to concrete'
     );
+
+    filter.values = ['P1Y', '2019-01-01'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['P1Y', '2019-01-01'], 'day', 'in'),
+      valuesForOperator(filter, 'day', 'in'),
       ['2018-01-01T00:00:00.000Z', '2019-01-01T00:00:00.000Z'],
       'in translates P1Y lookback to concrete'
     );
+
+    filter.values = ['2019-01-01', '2019-01-02'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['2019-01-01', '2019-01-02'], 'day', 'in'),
+      valuesForOperator(filter, 'day', 'in'),
       ['2019-01-01T00:00:00.000Z', '2019-01-02T00:00:00.000Z'],
       'in maps invalid interval to grain for day'
     );
+
+    filter.values = ['2019-01-01', '2019-01-08'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['2019-01-01', '2019-01-08'], 'isoWeek', 'in'),
+      valuesForOperator(filter, 'isoWeek', 'in'),
       ['2018-12-31T00:00:00.000Z', '2019-01-07T00:00:00.000Z'],
       'in maps invalid interval to grain for isoWeek'
     );
+
+    filter.values = ['2019-01-01', '2019-03-03'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['2019-01-01', '2019-03-03'], 'month', 'in'),
+      valuesForOperator(filter, 'month', 'in'),
       ['2019-01-01T00:00:00.000Z', '2019-03-01T00:00:00.000Z'],
       'in maps invalid interval to grain for month'
     );
+
+    filter.values = ['2019-01-01', '2019-05-01'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['2019-01-01', '2019-05-01'], 'quarter', 'in'),
+      valuesForOperator(filter, 'quarter', 'in'),
       ['2019-01-01T00:00:00.000Z', '2019-04-01T00:00:00.000Z'],
       'in maps invalid interval to grain for quarter'
     );
+
+    filter.values = ['2019-01-01', '2020-03-02'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['2019-01-01', '2020-03-02'], 'year', 'in'),
+      valuesForOperator(filter, 'year', 'in'),
       ['2019-01-01T00:00:00.000Z', '2020-01-01T00:00:00.000Z'],
       'in maps invalid interval to grain for year'
     );
 
     // 'since' tests
+
+    filter.values = ['2019-01-01', '2020-01-01'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['2019-01-01', '2020-01-01'], 'day', 'since'),
+      valuesForOperator(filter, 'day', 'since'),
       ['2019-01-01T00:00:00.000Z'],
       'since maps invalid interval to start/current for day'
     );
+
+    filter.values = ['2019-01-02', '2020-01-01'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['2019-01-02', '2020-01-01'], 'isoWeek', 'since'),
+      valuesForOperator(filter, 'isoWeek', 'since'),
       ['2018-12-31T00:00:00.000Z'],
       'since maps invalid interval start/end to start/current for isoWeek'
     );
+
+    filter.values = ['2019-01-02', '2020-01-01'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['2019-01-02', '2020-01-01'], 'month', 'since'),
+      valuesForOperator(filter, 'month', 'since'),
       ['2019-01-01T00:00:00.000Z'],
       'since maps invalid interval to start/current for month'
     );
+
+    filter.values = ['2019-05-01', '2020-01-01'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['2019-05-01', '2020-01-01'], 'quarter', 'since'),
+      valuesForOperator(filter, 'quarter', 'since'),
       ['2019-04-01T00:00:00.000Z'],
       'since maps invalid interval to start/current for quarter'
     );
+
+    filter.values = ['2019-03-01', '2020-01-01'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['2019-03-01', '2020-01-01'], 'year', 'since'),
+      valuesForOperator(filter, 'year', 'since'),
       ['2019-01-01T00:00:00.000Z'],
       'since maps invalid interval to start/current for year'
     );
+
+    filter.values = ['2019-01-01', '2020-01-01'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['2019-01-01', '2020-01-01'], 'day', 'since'),
+      valuesForOperator(filter, 'day', 'since'),
       ['2019-01-01T00:00:00.000Z'],
       'since translates start/end to start/current for day'
     );
+
+    filter.values = ['2018-12-31', '2020-01-01'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['2018-12-31', '2020-01-01'], 'isoWeek', 'since'),
+      valuesForOperator(filter, 'isoWeek', 'since'),
       ['2018-12-31T00:00:00.000Z'],
       'since translates start/end to start/current for isoWeek'
     );
+
+    filter.values = ['2019-03-01', '2020-01-01'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['2019-03-01', '2020-01-01'], 'quarter', 'since'),
+      valuesForOperator(filter, 'quarter', 'since'),
       ['2019-01-01T00:00:00.000Z'],
       'since translates start/end to start/current for quarter'
     );
+
+    filter.values = ['2019-01-01', '2020-01-01'];
     assert.deepEqual(
-      dateBuilder.valuesForOperator(['2019-01-01', '2020-01-01'], 'year', 'since'),
+      valuesForOperator(filter, 'year', 'since'),
       ['2019-01-01T00:00:00.000Z'],
       'since translates start/end to start/current for year'
     );
@@ -337,37 +398,37 @@ module('Unit | Component | filter-builders/time-dimension', function(hooks) {
      *   .add(1, 'day')
      *   .format(dateFormat);
      * assert.deepEqual(
-     *   dateBuilder.valuesForOperator(['current', 'next'], 'day', 'advanced'),
+     *   valuesForOperator(['current', 'next'], 'day', 'advanced'),
      *   [],
      *   'advanced translates start/end to PxD/end for year'
      * );
      * assert.deepEqual(
-     *   dateBuilder.valuesForOperator(last(4, 'day'), 'day', 'advanced'),
+     *   valuesForOperator(last(4, 'day'), 'day', 'advanced'),
      *   `P4D/${today}`,
      *   'Switching to inPast counts the days'
      * );
      * assert.deepEqual(
-     *   dateBuilder.valuesForOperator(['2019-01-02', '2020-01-01'], 'day', 'advanced'),
+     *   valuesForOperator(['2019-01-02', '2020-01-01'], 'day', 'advanced'),
      *   ['P364D', '2020-01-01'],
      *   'advanced translates start/end to PxD/end for day'
      * );
      * assert.deepEqual(
-     *   dateBuilder.valuesForOperator(['2018-12-31', '2020-01-01'], 'isoWeek', 'advanced'),
+     *   valuesForOperator(['2018-12-31', '2020-01-01'], 'isoWeek', 'advanced'),
      *   ['P366D', '2019-12-30'],
      *   'advanced translates start/end to PxD/end for isoWeek'
      * );
      * assert.deepEqual(
-     *   dateBuilder.valuesForOperator(['2019-02-01', '2020-01-01'], 'month', 'advanced'),
+     *   valuesForOperator(['2019-02-01', '2020-01-01'], 'month', 'advanced'),
      *   ['P334D', '2020-01-01'],
      *   'advanced translates start/end to PxD/end for month'
      * );
      * assert.deepEqual(
-     *   dateBuilder.valuesForOperator(['2019-03-01', '2020-01-01'], 'quarter', 'advanced'),
+     *   valuesForOperator(['2019-03-01', '2020-01-01'], 'quarter', 'advanced'),
      *   ['P306D', '2020-01-01'],
      *   'advanced translates start/end to PxD/end for quarter'
      * );
      * assert.deepEqual(
-     *   dateBuilder.valuesForOperator(['2019-01-01', '2020-01-01'], 'year', 'advanced'),
+     *   valuesForOperator(['2019-01-01', '2020-01-01'], 'year', 'advanced'),
      *   ['P365D', '2020-01-01'],
      *   'advanced translates start/end to PxD/end for year'
      * );

--- a/packages/reports/tests/unit/consumers/request/fili-test.ts
+++ b/packages/reports/tests/unit/consumers/request/fili-test.ts
@@ -134,7 +134,7 @@ module('Unit | Consumer | request fili', function(hooks) {
     );
     assert.deepEqual(
       dispatchedActionArgs,
-      [request.dateTimeFilter, { parameters: { grain: 'week' } }],
+      [request.dateTimeFilter, { parameters: { grain: 'week' }, values: ['P1W', 'current'] }],
       'UPDATE_FILTER is dispatched with the updated grain parameter'
     );
 


### PR DESCRIPTION
## Description
The fili consumer would update the grain parameter of a dateTime filter to match the column, but would not update the values so the displayed value would not match the queried one.

## Proposed Changes
- update the filter values when the grain changes
- Fix an issue with using isoweek for lookback

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
