### PR TITLE
New: Simple Request V2 Builder.

### DIFF
--- a/packages/data/addon/builder/requestV2.ts
+++ b/packages/data/addon/builder/requestV2.ts
@@ -1,0 +1,176 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ *
+ * Helper object for building request object used by fact service
+ */
+import { RequestV2, Parameters, FilterOperator, SortDirection } from 'navi-data/adapters/facts/interface';
+import { ColumnType } from 'navi-data/models/metadata/column';
+import { getDefaultDataSourceName } from 'navi-data/utils/adapter';
+import { nanoid } from 'nanoid';
+import { assert } from '@ember/debug';
+
+/**
+ * Utility Class for building a request V2
+ */
+export default class RequestV2Builder {
+  /**
+   * @property The request being built
+   */
+  private request: RequestV2;
+
+  /**
+   * @param request Optional request to use as base.
+   */
+  constructor(request?: RequestV2) {
+    if (!request) {
+      this.request = {
+        filters: [],
+        columns: [],
+        table: '',
+        dataSource: getDefaultDataSourceName(),
+        sorts: [],
+        limit: null,
+        requestVersion: '2.0'
+      };
+    } else {
+      this.request = JSON.parse(JSON.stringify(request));
+    }
+  }
+
+  /**
+   * Adds a column to the request
+   * @param type - metric, dimension, timeDimension
+   * @param field - name of the metric/dimension or timeDimension
+   * @param parameters - Dictionary of parameters
+   * @param alias - Optoinal Display name for the field
+   * @param cid - column id, generated if not given
+   */
+  column(type: ColumnType, field: string, parameters: Parameters, alias?: string, cid?: string): RequestV2Builder {
+    this.request.columns.push({
+      type,
+      field,
+      parameters,
+      ...(alias ? { alias } : null),
+      cid: cid ?? nanoid(10)
+    });
+    return this;
+  }
+
+  /**
+   * Convenience for adding a metric column
+   * @param metricName Name of metric
+   * @param parameters Dictionary of parameters
+   */
+  metric(metricName: string, parameters: Parameters = {}): RequestV2Builder {
+    this.column('metric', metricName, parameters);
+    return this;
+  }
+
+  /**
+   * Convenience for adding a dimension column
+   * @param dimensionName Name of dimension
+   * @param parameters Dictionary of parameters
+   */
+  dimension(dimensionName: string, parameters: Parameters = {}): RequestV2Builder {
+    this.column('dimension', dimensionName, parameters);
+    return this;
+  }
+
+  /**
+   * Adds a filter to the request
+   * @param type metric, dimension, or timeDimension
+   * @param field field name
+   * @param parameters dictionary of parameters
+   * @param operator operator
+   * @param values array of values for the filter
+   */
+  filter(
+    type: ColumnType,
+    field: string,
+    parameters: Parameters,
+    operator: FilterOperator,
+    values: (string | number | boolean)[]
+  ): RequestV2Builder {
+    this.request.filters.push({
+      type,
+      field,
+      parameters,
+      operator,
+      values
+    });
+    return this;
+  }
+
+  /**
+   * Adds a row limit to request
+   * @param limit number of max rows
+   */
+  limit(limit: number): RequestV2Builder {
+    this.request.limit = limit;
+    return this;
+  }
+
+  /**
+   * Adds sort to the request
+   * @param type metric,dimension or timeDimension
+   * @param field field name to sort by
+   * @param parameters Dictionary of parameters
+   * @param direction asc/desc
+   */
+  sort(type: ColumnType, field: string, parameters: Parameters, direction: SortDirection): RequestV2Builder {
+    this.request.sorts.push({
+      type,
+      field,
+      parameters,
+      direction
+    });
+    return this;
+  }
+
+  /**
+   * Adds table name to request
+   * @param name name of the table
+   */
+  table(name: string): RequestV2Builder {
+    this.request.table = name;
+    return this;
+  }
+
+  /**
+   * Allows specifies the datasource
+   * @param dataSource name of the datasource
+   */
+  dataSource(dataSource: string): RequestV2Builder {
+    this.request.dataSource = dataSource;
+    return this;
+  }
+
+  /**
+   * Convenience method for adding an interval filter
+   * @param grain 'day','week','month' etc... whatever your datasource supports
+   * @param start Period, datestring or macro
+   * @param end Period, datestring or macro
+   */
+  interval(grain: string, start: string, end: string): RequestV2Builder {
+    const table = this.request.table;
+    assert('Set the table before you set the interval', table.length !== 0);
+
+    this.column('timeDimension', `${table}.dateTime`, { grain }).filter(
+      'timeDimension',
+      `${table}.dateTime`,
+      { grain },
+      'bet',
+      [start, end]
+    );
+
+    return this;
+  }
+
+  /**
+   * Returns the built request
+   */
+  build() {
+    return this.request;
+  }
+}

--- a/packages/data/addon/builder/requestV2.ts
+++ b/packages/data/addon/builder/requestV2.ts
@@ -5,6 +5,7 @@
  * Helper object for building request object used by fact service
  */
 import { RequestV2, Parameters, FilterOperator, SortDirection } from 'navi-data/adapters/facts/interface';
+import { Grain } from 'navi-data/utils/date';
 import { ColumnType } from 'navi-data/models/metadata/column';
 import { getDefaultDataSourceName } from 'navi-data/utils/adapter';
 import { nanoid } from 'nanoid';
@@ -46,7 +47,7 @@ export default class RequestV2Builder {
    * @param alias - Optoinal Display name for the field
    * @param cid - column id, generated if not given
    */
-  column(type: ColumnType, field: string, parameters: Parameters, alias?: string, cid?: string): RequestV2Builder {
+  addColumn(type: ColumnType, field: string, parameters: Parameters, alias?: string, cid?: string): RequestV2Builder {
     this.request.columns.push({
       type,
       field,
@@ -62,8 +63,8 @@ export default class RequestV2Builder {
    * @param metricName Name of metric
    * @param parameters Dictionary of parameters
    */
-  metric(metricName: string, parameters: Parameters = {}): RequestV2Builder {
-    this.column('metric', metricName, parameters);
+  addMetric(metricName: string, parameters: Parameters = {}): RequestV2Builder {
+    this.addColumn('metric', metricName, parameters);
     return this;
   }
 
@@ -72,8 +73,8 @@ export default class RequestV2Builder {
    * @param dimensionName Name of dimension
    * @param parameters Dictionary of parameters
    */
-  dimension(dimensionName: string, parameters: Parameters = {}): RequestV2Builder {
-    this.column('dimension', dimensionName, parameters);
+  addDimension(dimensionName: string, parameters: Parameters = {}): RequestV2Builder {
+    this.addColumn('dimension', dimensionName, parameters);
     return this;
   }
 
@@ -85,7 +86,7 @@ export default class RequestV2Builder {
    * @param operator operator
    * @param values array of values for the filter
    */
-  filter(
+  addFilter(
     type: ColumnType,
     field: string,
     parameters: Parameters,
@@ -106,7 +107,7 @@ export default class RequestV2Builder {
    * Adds a row limit to request
    * @param limit number of max rows
    */
-  limit(limit: number): RequestV2Builder {
+  setLimit(limit: number): RequestV2Builder {
     this.request.limit = limit;
     return this;
   }
@@ -118,7 +119,7 @@ export default class RequestV2Builder {
    * @param parameters Dictionary of parameters
    * @param direction asc/desc
    */
-  sort(type: ColumnType, field: string, parameters: Parameters, direction: SortDirection): RequestV2Builder {
+  addSort(type: ColumnType, field: string, parameters: Parameters, direction: SortDirection): RequestV2Builder {
     this.request.sorts.push({
       type,
       field,
@@ -132,7 +133,7 @@ export default class RequestV2Builder {
    * Adds table name to request
    * @param name name of the table
    */
-  table(name: string): RequestV2Builder {
+  setTable(name: string): RequestV2Builder {
     this.request.table = name;
     return this;
   }
@@ -141,7 +142,7 @@ export default class RequestV2Builder {
    * Allows specifies the datasource
    * @param dataSource name of the datasource
    */
-  dataSource(dataSource: string): RequestV2Builder {
+  setDataSource(dataSource: string): RequestV2Builder {
     this.request.dataSource = dataSource;
     return this;
   }
@@ -152,11 +153,11 @@ export default class RequestV2Builder {
    * @param start Period, datestring or macro
    * @param end Period, datestring or macro
    */
-  interval(grain: string, start: string, end: string): RequestV2Builder {
+  addTimeRangeFilter(grain: Grain, start: string, end: string): RequestV2Builder {
     const table = this.request.table;
     assert('Set the table before you set the interval', table.length !== 0);
 
-    this.column('timeDimension', `${table}.dateTime`, { grain }).filter(
+    this.addColumn('timeDimension', `${table}.dateTime`, { grain }).addFilter(
       'timeDimension',
       `${table}.dateTime`,
       { grain },

--- a/packages/data/addon/builder/requestV2.ts
+++ b/packages/data/addon/builder/requestV2.ts
@@ -9,7 +9,6 @@ import { Grain } from 'navi-data/utils/date';
 import { ColumnType } from 'navi-data/models/metadata/column';
 import { getDefaultDataSourceName } from 'navi-data/utils/adapter';
 import { nanoid } from 'nanoid';
-import { assert } from '@ember/debug';
 
 /**
  * Utility Class for building a request V2
@@ -153,19 +152,11 @@ export default class RequestV2Builder {
    * @param start Period, datestring or macro
    * @param end Period, datestring or macro
    */
-  addTimeRangeFilter(grain: Grain, start: string, end: string): RequestV2Builder {
-    const table = this.request.table;
-    assert('Set the table before you set the interval', table.length !== 0);
-
-    this.addColumn('timeDimension', `${table}.dateTime`, { grain }).addFilter(
-      'timeDimension',
-      `${table}.dateTime`,
-      { grain },
-      'bet',
-      [start, end]
-    );
-
-    return this;
+  addTimeRangeFilter(columnId: string, grain: Grain, start: string, end: string): RequestV2Builder {
+    return this.addColumn('timeDimension', columnId, { grain }).addFilter('timeDimension', columnId, { grain }, 'bet', [
+      start,
+      end
+    ]);
   }
 
   /**

--- a/packages/data/package-lock.json
+++ b/packages/data/package-lock.json
@@ -17339,6 +17339,11 @@
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
       "optional": true
     },
+    "nanoid": {
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
+      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw=="
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -49,6 +49,7 @@
     "graphql-tag": "^2.10.1",
     "lodash-es": "^4.17.11",
     "miragejs": "^0.1.41",
+    "nanoid": "^3.1.20",
     "papaparse": "^5.1.1",
     "pretender": "^3.4.3"
   },

--- a/packages/data/tests/unit/builder/requestV2-test.ts
+++ b/packages/data/tests/unit/builder/requestV2-test.ts
@@ -7,14 +7,14 @@ module('Unit | Builder | Request V2', function() {
     assert.expect(1);
     const request = new RequestV2Builder();
     const built: RequestV2 = request
-      .table('clicks')
-      .interval('day', 'P3D', 'current')
-      .metric('clicks', { aggregation: '2DayAvg', trend: 'YoY' })
-      .dimension('browser')
-      .filter('dimension', 'browser', { field: 'id' }, 'eq', ['chrome'])
-      .filter('metric', 'clicks', { aggregation: '2DayAvg', trend: 'YoY' }, 'gt', [80000])
-      .limit(80000)
-      .sort('metric', 'clicks', { aggregation: '2DayAvg', trend: 'YoY' }, 'desc')
+      .setTable('clicks')
+      .addTimeRangeFilter('day', 'P3D', 'current')
+      .addMetric('clicks', { aggregation: '2DayAvg', trend: 'YoY' })
+      .addDimension('browser')
+      .addFilter('dimension', 'browser', { field: 'id' }, 'eq', ['chrome'])
+      .addFilter('metric', 'clicks', { aggregation: '2DayAvg', trend: 'YoY' }, 'gt', [80000])
+      .setLimit(80000)
+      .addSort('metric', 'clicks', { aggregation: '2DayAvg', trend: 'YoY' }, 'desc')
       .build();
 
     //strip out cid for easy compare
@@ -102,15 +102,15 @@ module('Unit | Builder | Request V2', function() {
     assert.expect(1);
     const baseRequest = new RequestV2Builder();
     const built = baseRequest
-      .table('clicks')
-      .interval('day', 'P1D', 'current')
+      .setTable('clicks')
+      .addTimeRangeFilter('day', 'P1D', 'current')
       .build();
 
     const fullRequest = new RequestV2Builder(built);
     const fullBuild = fullRequest
-      .metric('clicks')
-      .dimension('browser')
-      .filter('metric', 'clicks', {}, 'gt', [10000])
+      .addMetric('clicks')
+      .addDimension('browser')
+      .addFilter('metric', 'clicks', {}, 'gt', [10000])
       .build();
 
     //strip out cid for easy compare

--- a/packages/data/tests/unit/builder/requestV2-test.ts
+++ b/packages/data/tests/unit/builder/requestV2-test.ts
@@ -8,7 +8,7 @@ module('Unit | Builder | Request V2', function() {
     const request = new RequestV2Builder();
     const built: RequestV2 = request
       .setTable('clicks')
-      .addTimeRangeFilter('day', 'P3D', 'current')
+      .addTimeRangeFilter('clicks.dateTime', 'day', 'P3D', 'current')
       .addMetric('clicks', { aggregation: '2DayAvg', trend: 'YoY' })
       .addDimension('browser')
       .addFilter('dimension', 'browser', { field: 'id' }, 'eq', ['chrome'])
@@ -103,7 +103,7 @@ module('Unit | Builder | Request V2', function() {
     const baseRequest = new RequestV2Builder();
     const built = baseRequest
       .setTable('clicks')
-      .addTimeRangeFilter('day', 'P1D', 'current')
+      .addTimeRangeFilter('clicks.dateTime', 'day', 'P1D', 'current')
       .build();
 
     const fullRequest = new RequestV2Builder(built);

--- a/packages/data/tests/unit/builder/requestV2-test.ts
+++ b/packages/data/tests/unit/builder/requestV2-test.ts
@@ -1,0 +1,171 @@
+import { RequestV2 } from 'navi-data/adapters/facts/interface';
+import RequestV2Builder from 'navi-data/builder/requestV2';
+import { module, test } from 'qunit';
+
+module('Unit | Builder | Request V2', function() {
+  test('Can build requests', assert => {
+    assert.expect(1);
+    const request = new RequestV2Builder();
+    const built: RequestV2 = request
+      .table('clicks')
+      .interval('day', 'P3D', 'current')
+      .metric('clicks', { aggregation: '2DayAvg', trend: 'YoY' })
+      .dimension('browser')
+      .filter('dimension', 'browser', { field: 'id' }, 'eq', ['chrome'])
+      .filter('metric', 'clicks', { aggregation: '2DayAvg', trend: 'YoY' }, 'gt', [80000])
+      .limit(80000)
+      .sort('metric', 'clicks', { aggregation: '2DayAvg', trend: 'YoY' }, 'desc')
+      .build();
+
+    //strip out cid for easy compare
+    built.columns = built.columns.map(col => {
+      delete col.cid;
+      return col;
+    });
+
+    assert.deepEqual(
+      built,
+      {
+        table: 'clicks',
+        columns: [
+          {
+            field: 'clicks.dateTime',
+            parameters: {
+              grain: 'day'
+            },
+            type: 'timeDimension'
+          },
+          {
+            field: 'clicks',
+            parameters: {
+              aggregation: '2DayAvg',
+              trend: 'YoY'
+            },
+            type: 'metric'
+          },
+          {
+            field: 'browser',
+            parameters: {},
+            type: 'dimension'
+          }
+        ],
+        filters: [
+          {
+            field: 'clicks.dateTime',
+            operator: 'bet',
+            parameters: {
+              grain: 'day'
+            },
+            type: 'timeDimension',
+            values: ['P3D', 'current']
+          },
+          {
+            field: 'browser',
+            operator: 'eq',
+            parameters: {
+              field: 'id'
+            },
+            type: 'dimension',
+            values: ['chrome']
+          },
+          {
+            field: 'clicks',
+            operator: 'gt',
+            parameters: {
+              aggregation: '2DayAvg',
+              trend: 'YoY'
+            },
+            type: 'metric',
+            values: [80000]
+          }
+        ],
+        sorts: [
+          {
+            direction: 'desc',
+            field: 'clicks',
+            parameters: {
+              aggregation: '2DayAvg',
+              trend: 'YoY'
+            },
+            type: 'metric'
+          }
+        ],
+        limit: 80000,
+        requestVersion: '2.0',
+        dataSource: 'bardOne'
+      },
+      'Builds correct request'
+    );
+  });
+
+  test('Build from base request', assert => {
+    assert.expect(1);
+    const baseRequest = new RequestV2Builder();
+    const built = baseRequest
+      .table('clicks')
+      .interval('day', 'P1D', 'current')
+      .build();
+
+    const fullRequest = new RequestV2Builder(built);
+    const fullBuild = fullRequest
+      .metric('clicks')
+      .dimension('browser')
+      .filter('metric', 'clicks', {}, 'gt', [10000])
+      .build();
+
+    //strip out cid for easy compare
+    fullBuild.columns = fullBuild.columns.map(col => {
+      delete col.cid;
+      return col;
+    });
+
+    assert.deepEqual(
+      fullBuild,
+      {
+        columns: [
+          {
+            field: 'clicks.dateTime',
+            parameters: {
+              grain: 'day'
+            },
+            type: 'timeDimension'
+          },
+          {
+            field: 'clicks',
+            parameters: {},
+            type: 'metric'
+          },
+          {
+            field: 'browser',
+            parameters: {},
+            type: 'dimension'
+          }
+        ],
+        dataSource: 'bardOne',
+        filters: [
+          {
+            field: 'clicks.dateTime',
+            operator: 'bet',
+            parameters: {
+              grain: 'day'
+            },
+            type: 'timeDimension',
+            values: ['P1D', 'current']
+          },
+          {
+            field: 'clicks',
+            operator: 'gt',
+            parameters: {},
+            type: 'metric',
+            values: [10000]
+          }
+        ],
+        limit: null,
+        requestVersion: '2.0',
+        sorts: [],
+        table: 'clicks'
+      },
+      'Building from base request'
+    );
+  });
+});


### PR DESCRIPTION
## Description

In our projects we often use the request builder to make custom dashboards. Now that we moving onto RequestV2 would nice to have a builder for it.

## Proposed Changes

- Add a TypeScript RequestV2 builder
- Works a bit differently from the old one. Instead of attempting to do immutable operations. does a deep copy of the base request and then holds it as private state until you call build().

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
