### PR TITLE
Update: Load all tables but hide non-fact ones

### DIFF
--- a/packages/data/addon/gql/fragments/table.ts
+++ b/packages/data/addon/gql/fragments/table.ts
@@ -11,6 +11,7 @@ const fragment = gql`
     description
     category
     cardinality
+    isFact
     metrics {
       edges {
         node {

--- a/packages/data/addon/gql/queries/tables.ts
+++ b/packages/data/addon/gql/queries/tables.ts
@@ -7,7 +7,7 @@ import TableFragment from '../fragments/table';
 
 const query = gql`
   query {
-    table(filter: "isFact==true") {
+    table {
       edges {
         node {
           ...TableFragment

--- a/packages/data/addon/models/metadata/table.ts
+++ b/packages/data/addon/models/metadata/table.ts
@@ -23,6 +23,7 @@ export interface TableMetadataPayload {
   category?: string;
   description?: string;
   cardinality: typeof CARDINALITY_SIZES[number];
+  isFact: boolean;
   metricIds: string[];
   dimensionIds: string[];
   timeDimensionIds: string[];
@@ -37,6 +38,7 @@ export interface TableMetadata {
   category?: string;
   description?: string;
   cardinality: typeof CARDINALITY_SIZES[number];
+  isFact: boolean;
   metrics: MetricMetadataModel[];
   dimensions: DimensionMetadataModel[];
   timeDimensions: TimeDimensionMetadataModel[];
@@ -83,6 +85,11 @@ export default class TableMetadataModel extends EmberObject implements TableMeta
    * @param {CaridnalitySize} cardinality
    */
   cardinality!: typeof CARDINALITY_SIZES[number];
+
+  /**
+   * @param {boolean} isFact
+   */
+  isFact = true;
 
   /**
    * @property {string[]} metricIds - array of metric ids

--- a/packages/data/addon/serializers/metadata/bard.ts
+++ b/packages/data/addon/serializers/metadata/bard.ts
@@ -181,6 +181,7 @@ export default class BardMetadataSerializer extends NaviMetadataSerializer {
         description: table.description,
         category: table.category,
         cardinality: allTableColumns.tableCardinality,
+        isFact: true,
         timeGrainIds: table.timeGrains.map(grain => grain.name),
         source: dataSourceName,
         metricIds: [...allTableColumns.tableMetricIds],

--- a/packages/data/addon/serializers/metadata/elide.ts
+++ b/packages/data/addon/serializers/metadata/elide.ts
@@ -59,6 +59,7 @@ type TableNode = {
   description: string;
   category: string;
   cardinality: typeof CARDINALITY_SIZES[number];
+  isFact: boolean;
   metrics: Connection<MetricNode>;
   dimensions: Connection<DimensionNode>;
   timeDimensions: Connection<TimeDimensionNode>;
@@ -95,6 +96,7 @@ export default class ElideMetadataSerializer extends NaviMetadataSerializer {
         category: table.category,
         description: table.description,
         cardinality: table.cardinality,
+        isFact: table.isFact,
         metricIds: [],
         dimensionIds: [],
         timeDimensionIds: [],

--- a/packages/data/tests/unit/adapters/metadata/elide-test.ts
+++ b/packages/data/tests/unit/adapters/metadata/elide-test.ts
@@ -82,6 +82,7 @@ module('Unit | Adapter | metadata/elide', function(hooks) {
       'description',
       'category',
       'cardinality',
+      'isFact',
       'metrics',
       'dimensions',
       'timeDimensions',
@@ -297,6 +298,7 @@ module('Unit | Adapter | metadata/elide', function(hooks) {
                 description: 'This is Table 0',
                 category: 'categoryOne',
                 cardinality: 'SMALL',
+                isFact: true,
                 metrics: {
                   edges: [
                     {

--- a/packages/data/tests/unit/serializers/metadata/bard-test.ts
+++ b/packages/data/tests/unit/serializers/metadata/bard-test.ts
@@ -298,6 +298,7 @@ const Payload: RawEverythingPayload = {
 const TablePayloads: TableMetadataPayload[] = [
   {
     cardinality: 'MEDIUM',
+    isFact: true,
     category: 'General',
     description: 'Table Description',
     dimensionIds: ['dimensionOne', 'dimensionTwo'],
@@ -310,6 +311,7 @@ const TablePayloads: TableMetadataPayload[] = [
   },
   {
     cardinality: 'MEDIUM',
+    isFact: true,
     category: 'Special',
     description: "Second table's description",
     dimensionIds: ['dimensionTwo'],

--- a/packages/data/tests/unit/serializers/metadata/elide-test.ts
+++ b/packages/data/tests/unit/serializers/metadata/elide-test.ts
@@ -38,6 +38,7 @@ module('Unit | Serializer | metadata/elide', function(hooks) {
               description: 'Table A',
               category: 'cat1',
               cardinality: 'SMALL',
+              isFact: true,
               metrics: {
                 edges: [
                   {
@@ -133,6 +134,7 @@ module('Unit | Serializer | metadata/elide', function(hooks) {
               description: 'Table B',
               category: 'cat2',
               cardinality: 'MEDIUM',
+              isFact: true,
               metrics: {
                 edges: [
                   {
@@ -222,6 +224,7 @@ module('Unit | Serializer | metadata/elide', function(hooks) {
         description: 'Table A',
         category: 'cat1',
         cardinality: 'SMALL',
+        isFact: true,
         metricIds: ['tableA.m1'],
         dimensionIds: ['tableA.d1', 'tableA.d2'],
         timeDimensionIds: ['tableA.td1'],
@@ -233,6 +236,7 @@ module('Unit | Serializer | metadata/elide', function(hooks) {
         description: 'Table B',
         category: 'cat2',
         cardinality: 'MEDIUM',
+        isFact: true,
         metricIds: ['tableB.m2', 'tableB.m3'],
         dimensionIds: ['tableB.d1', 'tableB.d2'],
         timeDimensionIds: [],

--- a/packages/reports/addon/components/report-builder.js
+++ b/packages/reports/addon/components/report-builder.js
@@ -9,6 +9,7 @@ import { computed, action } from '@ember/object';
 import layout from '../templates/components/report-builder';
 import { canonicalizeMetric } from 'navi-data/utils/metric';
 import { layout as templateLayout, tagName } from '@ember-decorators/component';
+import { A } from '@ember/array';
 
 @templateLayout(layout)
 @tagName('')
@@ -35,7 +36,8 @@ export default class ReportBuilderComponent extends Component {
    */
   @computed
   get allTables() {
-    return this.metadataService.all('table').sortBy('name');
+    const factTables = this.metadataService.all('table').filter(t => t.isFact === true);
+    return A(factTables).sortBy('name');
   }
 
   /**

--- a/packages/reports/addon/routes/reports/new.js
+++ b/packages/reports/addon/routes/reports/new.js
@@ -8,6 +8,7 @@ import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { get } from '@ember/object';
 import config from 'ember-get-config';
+import { A } from '@ember/array';
 
 export default Route.extend({
   /**
@@ -113,10 +114,10 @@ export default Route.extend({
    */
   _getDefaultTable() {
     const { metadataService } = this;
-    let table = metadataService.all('table').findBy('id', config.navi.defaultDataTable);
+    const factTables = metadataService.all('table').filter(t => t.isFact === true);
+    let table = factTables.find(t => t.id === config.navi.defaultDataTable);
     if (!table) {
-      let tables = metadataService.all('table').sortBy('name');
-      table = tables[0];
+      table = A(factTables).sortBy('name')[0];
     }
     return table;
   }

--- a/packages/reports/tests/unit/components/report-builder-test.js
+++ b/packages/reports/tests/unit/components/report-builder-test.js
@@ -1,6 +1,5 @@
 import { A as arr } from '@ember/array';
 import { get, set } from '@ember/object';
-import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
@@ -10,31 +9,32 @@ module('Unit | Component | Report Builder', function(hooks) {
   test('allTables', function(assert) {
     assert.expect(1);
 
-    let component = run(() => this.owner.factoryFor('component:report-builder').create()),
-      expectedOrdering = [
-        { name: '12345', id: '2' },
-        { name: '9876', id: '1' },
-        { name: 'advertisement', id: '8' },
-        { name: 'Advertisement', id: '7' },
-        { name: 'DATASOURCE_A', id: '4' },
-        { name: 'DATASOURCE_B', id: '3' },
-        { name: 'table-A', id: '6' },
-        { name: 'table-B', id: '5' }
-      ];
+    let component = this.owner.factoryFor('component:report-builder').create();
     set(component, 'metadataService', {
       all: () =>
         arr([
-          { name: '9876', id: '1' },
-          { name: '12345', id: '2' },
-          { name: 'DATASOURCE_B', id: '3' },
-          { name: 'DATASOURCE_A', id: '4' },
-          { name: 'table-B', id: '5' },
-          { name: 'table-A', id: '6' },
-          { name: 'Advertisement', id: '7' },
-          { name: 'advertisement', id: '8' }
+          { name: '12345', id: '2', isFact: true },
+          { name: '9876', id: '1', isFact: false },
+          { name: 'DATASOURCE_B', id: '3', isFact: true },
+          { name: 'DATASOURCE_A', id: '4', isFact: true },
+          { name: 'table-B', id: '5', isFact: true },
+          { name: 'Advertisement', id: '7', isFact: true },
+          { name: 'table-A', id: '6', isFact: false },
+          { name: 'advertisement', id: '8', isFact: true }
         ])
     });
 
-    assert.deepEqual(get(component, 'allTables'), expectedOrdering, 'List of tables are sorted alphabetically');
+    assert.deepEqual(
+      get(component, 'allTables'),
+      [
+        { name: '12345', id: '2', isFact: true },
+        { name: 'advertisement', id: '8', isFact: true },
+        { name: 'Advertisement', id: '7', isFact: true },
+        { name: 'DATASOURCE_A', id: '4', isFact: true },
+        { name: 'DATASOURCE_B', id: '3', isFact: true },
+        { name: 'table-B', id: '5', isFact: true }
+      ],
+      'List of tables are sorted alphabetically and filtered to fact tables'
+    );
   });
 });


### PR DESCRIPTION
## Description
We currently filter elide tables to only fetch the fact ones in order to hide tables for application data (reports/async queries/etc), but elide fact tables can point to non-fact tables for sourcing dimension values

## Proposed Changes
- Hide non-fact tables from the UI, but keep the metadata loaded for providing faster dimension lookups

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
