### PR TITLE
Docker image build integration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+node_modules
+packages/*/node_modules

--- a/container/docker/Dockerfile.alpine
+++ b/container/docker/Dockerfile.alpine
@@ -1,0 +1,22 @@
+FROM alpine:latest
+
+RUN apk add nodejs
+RUN apk add npm
+RUN apk add openjdk11-jdk
+
+ENV PORT=8080
+COPY . /usr/src/yavin
+
+ENV DISABLE_MOCKS=true
+WORKDIR /usr/src/yavin
+RUN  npm ci -verbose
+RUN  node_modules/.bin/lerna bootstrap --hoist --ci --concurrency=2 --loglevel warn
+RUN  node_modules/.bin/lerna run build --scope navi-app --stream
+
+WORKDIR /usr/src/yavin/packages/webservice
+RUN ./gradlew bootJar -x installUIDependencies
+RUN cp -r ./../app/dist app/build/resources/main/META-INF/resources/ui
+
+WORKDIR /
+RUN cp /usr/src/yavin/packages/webservice/app/build/libs/app-*.jar /usr/local/lib/
+RUN rm -rf /usr/src/yavin

--- a/container/docker/Dockerfile.demo_local
+++ b/container/docker/Dockerfile.demo_local
@@ -1,0 +1,3 @@
+FROM verizonmedia/yavin_base:latest
+
+CMD java -Xmx224m -jar /usr/local/lib/app-*.jar

--- a/container/docker/README.md
+++ b/container/docker/README.md
@@ -1,0 +1,48 @@
+# Run Yavin in Docker containers
+
+Yavin can be easily deployed using docker containers. We maintain multiple dockerfiles for different types of images. However there will be one common base image.
+
+## Docker registry
+
+We use docker hub to keep our images updated and available. Docker hub is integrated back to github. It will detect changes to the master branch and build (and tag) images automatically. The permission to docker hub is limited to few users only.
+
+https://hub.docker.com/repository/docker/verizonmedia/yavin/general
+[Yavin DockerHub](https://hub.docker.com/repository/docker/verizonmedia/yavin/general)
+
+```
+org: verizonmedia
+repo: yavin_base, yavin_demo, yavin
+```
+
+## Docker file for base image
+
+We create a base image using Alpine Linux. This base image will have all the requried dependencies available. It will not have any entrypoint.
+
+```
+Dockerfile.alpine
+```
+
+## Yavin Base image
+
+For any other environments like heroku (or cloud) use base image ```verizonmedia/yavin_base:latest```
+In your custom Dockerfile you can start as:
+```
+FROM verizonmedia/yavin_base:latest
+```
+
+## Docker file for local demo
+docker build -f container/docker/Docker.alpine
+
+```
+Dockerfile.demo_local
+```
+
+## Yavin Local demo image
+For any other environments like heroku (or cloud) use base image ```verizonmedia/yavin_demo:latest```
+To run yavin demo using docker container:
+```
+docker run -p 9999:8080 verizonmedia/yavin_demo:latest
+```
+
+## Heroku launch
+Coming soon...

--- a/packages/webservice/app/build.gradle.kts
+++ b/packages/webservice/app/build.gradle.kts
@@ -6,7 +6,6 @@ description = "app"
 plugins {
     id("org.springframework.boot") version "2.3.1.RELEASE"
     id("io.spring.dependency-management") version "1.0.9.RELEASE"
-    id("com.github.johnrengelman.shadow") version "5.2.0"
     kotlin("jvm")
     kotlin("plugin.spring") version "1.3.72"
     id("com.github.node-gradle.node") version "2.2.4"
@@ -25,7 +24,7 @@ repositories {
 dependencies {
     implementation(project(":models"))
     implementation("org.springframework.boot:spring-boot-starter-security")
-    implementation("com.yahoo.elide", "elide-spring-boot-starter", "5.0.0-pr30")
+    implementation("com.yahoo.elide", "elide-spring-boot-starter", "5.0.0-pr29")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.h2database", "h2", "1.3.176")
     implementation( "org.hibernate", "hibernate-validator", "6.1.5.Final")
@@ -57,7 +56,7 @@ tasks.withType<KotlinCompile> {
 }
 
 tasks.register<NpmTask>("installUIDependencies") {
-    setArgs(listOf("ci"))
+    setArgs(listOf("ci", "-verbose"))
     setExecOverrides(closureOf<ExecSpec> {
         setWorkingDir("../../../")
     })
@@ -74,7 +73,6 @@ tasks.register<Copy>("copyNaviApp") {
     from("../../app/dist")
     into("$buildDir/resources/main/META-INF/resources/ui")
 }
-
 
 tasks.register<Exec>("execJar") {
     dependsOn("bootJar")

--- a/packages/webservice/app/build.gradle.kts
+++ b/packages/webservice/app/build.gradle.kts
@@ -24,7 +24,7 @@ repositories {
 dependencies {
     implementation(project(":models"))
     implementation("org.springframework.boot:spring-boot-starter-security")
-    implementation("com.yahoo.elide", "elide-spring-boot-starter", "5.0.0-pr29")
+    implementation("com.yahoo.elide", "elide-spring-boot-starter", "5.0.0-pr30")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.h2database", "h2", "1.3.176")
     implementation( "org.hibernate", "hibernate-validator", "6.1.5.Final")


### PR DESCRIPTION
Resolves # 
- Docker images getting out of date.
- Docker image size was over 4 GB due to duplicate dependencies in node modules.

<!-- The above line will close the issue upon merge -->

## Description
Docker container integration.
Optimized node_module dependency
Readme for docker related information.

## Proposed Changes
-
add Dockerfiles
add readme.
final integration and image build workflow is in side docker hub.

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
