### PR TITLE
Update: Remove all grain

### DIFF
--- a/packages/core/addon/serializers/table.ts
+++ b/packages/core/addon/serializers/table.ts
@@ -119,7 +119,7 @@ function buildColumnInfo(request: RequestV2, visualization: TableVisMetadataPayl
     if (newCol.type === 'dateTime') {
       const { table } = request;
       const grain = request.columns.find(c => c.field === `${table}.dateTime`)?.parameters.grain;
-      canonicalName = `${table}.${canonicalName}(grain=${grain || 'all'})`;
+      canonicalName = `${table}.${canonicalName}(grain=${grain})`;
     } else if (newCol.type === 'dimension') {
       canonicalName = `${canonicalName}(field=id)`;
     }
@@ -186,7 +186,7 @@ export function normalizeTableV2(
     if (showTotals?.subtotal === 'dateTime') {
       const { table } = request;
       const grain = request.columns.find(c => c.field === `${table}.dateTime`)?.parameters.grain;
-      canonicalName = `${table}.dateTime(grain=${grain || 'all'})`;
+      canonicalName = `${table}.dateTime(grain=${grain})`;
     } else {
       canonicalName = `${showTotals.subtotal}(field=id)`;
     }

--- a/packages/core/addon/utils/chart-axis-date-time-formats.ts
+++ b/packages/core/addon/utils/chart-axis-date-time-formats.ts
@@ -9,7 +9,6 @@ const grainFormats: Record<Grain, string> = {
   second: 'HH:mm:ss',
   minute: 'HH:mm:00',
   hour: 'HH:00',
-  all: 'MMM D',
   day: 'MMM D',
   week: 'MMM D',
   isoWeek: 'MMM D',

--- a/packages/core/tests/unit/chart-builders/dimension-test.ts
+++ b/packages/core/tests/unit/chart-builders/dimension-test.ts
@@ -186,52 +186,6 @@ module('Unit | Chart Builders | Dimension', function(hooks) {
     );
   });
 
-  test('groupDataBySeries all granularity - many dimensions of same type', function(assert) {
-    assert.expect(1);
-
-    const request = buildTestRequest(
-      metrics,
-      [ageDim],
-      { start: '2016-05-30 00:00:00.000', end: '2016-05-30 00:00:00.000' },
-      'all'
-    );
-    const data = NaviFactResponse.create({
-      //prettier-ignore
-      rows: [
-        { 'network.dateTime(grain=all)': '2016-05-30 00:00:00.000', 'age(field=id)': '-3', totalPageViews: 3669828357 },
-        { 'network.dateTime(grain=all)': '2016-05-30 00:00:00.000', 'age(field=id)': '1', totalPageViews: 3669828357 }
-      ]
-    });
-
-    assert.deepEqual(
-      DimensionChartBuilder.buildData(
-        data,
-        {
-          metricCid: 'cid_totalPageViews',
-          dimensions: [
-            { name: 'All Other', values: { cid_age: '-3' } },
-            { name: 'Under 13', values: { cid_age: '1' } }
-          ]
-        },
-        request
-      ),
-      {
-        series: ([
-          {
-            x: { rawValue: '2016-05-30 00:00:00.000', displayValue: 'May 30' },
-            'series.0': 3669828357,
-            'series.1': 3669828357
-          }
-        ] as unknown) as C3Row[],
-        names: {
-          'series.0': 'All Other',
-          'series.1': 'Under 13'
-        }
-      },
-      'A series has the properly formatted displayValue'
-    );
-  });
-
   test('groupDataBySeries hour granularity - many dimensions of same type', function(assert) {
     assert.expect(1);
 

--- a/packages/core/tests/unit/helpers/format-date-for-granularity-test.js
+++ b/packages/core/tests/unit/helpers/format-date-for-granularity-test.js
@@ -1,18 +1,7 @@
 import { formatDateForGranularity } from 'dummy/helpers/format-date-for-granularity';
 import { module, test } from 'qunit';
-import moment from 'moment';
 
 module('Unit | Helper | format date for granularity', function() {
-  test('all', function(assert) {
-    assert.expect(1);
-
-    assert.equal(
-      formatDateForGranularity('2016-06-03 11:12:13.000', 'all'),
-      '06/03/2016',
-      'The date is formatted to only display the month/day/year'
-    );
-  });
-
   test('quarter', function(assert) {
     assert.expect(1);
 
@@ -40,21 +29,7 @@ module('Unit | Helper | format date for granularity', function() {
   });
 
   test('validity', function(assert) {
-    assert.expect(5);
-
-    assert.equal(
-      formatDateForGranularity('2015-03-02', 'all'),
-      '03/02/2015',
-      'helper formats date string for a valid date'
-    );
-
-    assert.equal(
-      formatDateForGranularity(moment('2015-12-30 00:00:00.000'), 'all'),
-      '12/30/2015',
-      'helper formats date string for a valid moment object'
-    );
-
-    assert.equal(formatDateForGranularity('invalid', 'all'), '--', "helper returns '--' for an invalid date");
+    assert.expect(2);
 
     assert.equal(formatDateForGranularity(null), '--', "helper returns '--' for null");
 

--- a/packages/core/tests/unit/models/bard-request-v2/request-test.js
+++ b/packages/core/tests/unit/models/bard-request-v2/request-test.js
@@ -131,7 +131,7 @@ module('Unit | Model | Fragment | BardRequest  - Request', function(hooks) {
 
     assert.deepEqual(
       timeDimension.supportedGrains.map(g => g.grain),
-      ['Hour', 'Day', 'Week', 'Month', 'Quarter', 'Year', 'All'],
+      ['Hour', 'Day', 'IsoWeek', 'Month', 'Quarter', 'Year'],
       'meta data is populated on sub fragments'
     );
 
@@ -140,7 +140,7 @@ module('Unit | Model | Fragment | BardRequest  - Request', function(hooks) {
 
     assert.deepEqual(
       timeDimension.supportedGrains.map(g => g.grain),
-      ['Day', 'Week', 'Month', 'Quarter', 'Year', 'All'],
+      ['Day', 'IsoWeek', 'Month', 'Quarter', 'Year'],
       'meta data is populated on sub fragments'
     );
 

--- a/packages/data/addon/adapters/facts/bard.ts
+++ b/packages/data/addon/adapters/facts/bard.ts
@@ -8,7 +8,6 @@
 import { assert, warn } from '@ember/debug';
 import { inject as service } from '@ember/service';
 import { A as array } from '@ember/array';
-import { assign } from '@ember/polyfills';
 import EmberObject from '@ember/object';
 import { canonicalizeMetric } from '../../utils/metric';
 import { configHost } from '../../utils/adapter';
@@ -237,9 +236,7 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
     const grains = [...new Set(dateTimeColumns.map(c => c.parameters.grain))] as Grain[];
     if (grains.length > 1) {
       throw new FactAdapterError(
-        `Requesting more than one '${request.table}.dateTime' grain is not supported. You requested [${grains.join(
-          ','
-        )}]`
+        `Requesting more than multiple 'Date Time' grains is not supported. You requested [${grains.join(',')}]`
       );
     }
     let timeGrain: GrainWithAll = grains.length === 1 ? grains[0] : 'all';
@@ -250,7 +247,7 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
       | BardTableMetadataModel
       | undefined;
     if (timeGrain === 'all' && tableMeta?.hasAllGrain === false) {
-      throw new FactAdapterError(`Table '${table}' requires exactly 1 'Date Time' column, you have 0.`);
+      throw new FactAdapterError(`Table '${table}' requires requesting 'Date Time' column exactly once.`);
     }
 
     return `${host}/${namespace}/${table}/${timeGrain}${dimensions}/`;
@@ -285,7 +282,7 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
 
     //catch all query param and add to the query
     if (queryParams) {
-      assign(query, queryParams);
+      Object.assign(query, queryParams);
     }
 
     return query;

--- a/packages/data/addon/adapters/facts/bard.ts
+++ b/packages/data/addon/adapters/facts/bard.ts
@@ -236,7 +236,7 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
     const grains = [...new Set(dateTimeColumns.map(c => c.parameters.grain))] as Grain[];
     if (grains.length > 1) {
       throw new FactAdapterError(
-        `Requesting more than multiple 'Date Time' grains is not supported. You requested [${grains.join(',')}]`
+        `Requesting multiple 'Date Time' grains is not supported. You requested [${grains.join(',')}]`
       );
     }
     let timeGrain: GrainWithAll = grains.length === 1 ? grains[0] : 'all';

--- a/packages/data/addon/mirage/routes/bard-lite.ts
+++ b/packages/data/addon/mirage/routes/bard-lite.ts
@@ -18,6 +18,7 @@ import {
   parseMetrics
 } from './bard-lite-parsers';
 import { getPeriodForGrain, Grain } from 'navi-data/utils/date';
+import { GrainWithAll } from 'navi-data/serializers/metadata/bard';
 
 const API_DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss.SSS',
   DIMENSION_VALUE_MAP: Record<string, DimensionRow[]> = {},
@@ -64,7 +65,7 @@ const global = window as Window &
  * @param end - end of time period - must be 'current' or fixed date
  * @returns list of moments in requested time range
  */
-function _getDates(grain: Grain, start: string, end: string) {
+function _getDates(grain: GrainWithAll, start: string, end: string) {
   const isoGrain = grain === 'week' ? 'isoWeek' : grain; // need to use isoweek, which is what real ws uses
   let endDate;
   const nonAllGrain = isoGrain === 'all' ? 'day' : isoGrain;
@@ -193,11 +194,7 @@ export default function(
     }
 
     // Convert each date into a row of data
-    let rows: ResponseRow[] = dates.map(date => {
-      return {
-        dateTime: date.format(API_DATE_FORMAT)
-      };
-    });
+    let rows: ResponseRow[] = dates.map(date => ({ dateTime: date.format(API_DATE_FORMAT) }));
 
     // Add id and desc for each dimension
     dimensions.forEach(dimension => {

--- a/packages/data/addon/models/metadata/bard/table.ts
+++ b/packages/data/addon/models/metadata/bard/table.ts
@@ -1,4 +1,8 @@
-import { Grain } from 'navi-data/utils/date';
+/**
+ * Copyright 2021, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+import { Grain, Grains } from 'navi-data/utils/date';
 import TableMetadataModel, { TableMetadata, TableMetadataPayload } from '../table';
 import { upperFirst, sortBy } from 'lodash-es';
 
@@ -17,17 +21,7 @@ export interface BardTableMetadata extends TableMetadata {
   hasAllGrain: boolean;
 }
 
-export const GrainOrdering: Record<Grain, number> = {
-  second: 1,
-  minute: 2,
-  hour: 3,
-  day: 4,
-  week: 5,
-  isoWeek: 5,
-  month: 6,
-  quarter: 7,
-  year: 8
-};
+export const GrainOrdering = Object.fromEntries(Grains.map((g, i) => [g, i])) as Record<Grain, number>;
 
 export default class BardTableMetadataModel extends TableMetadataModel implements BardTableMetadataModel {
   init() {

--- a/packages/data/addon/models/metadata/bard/table.ts
+++ b/packages/data/addon/models/metadata/bard/table.ts
@@ -1,0 +1,55 @@
+import { Grain } from 'navi-data/utils/date';
+import TableMetadataModel, { TableMetadata, TableMetadataPayload } from '../table';
+import { upperFirst, sortBy } from 'lodash-es';
+
+export type TimeGrain = {
+  id: Grain;
+  name: string;
+};
+
+export interface BardTableMetadataPayload extends TableMetadataPayload {
+  timeGrainIds: Grain[];
+  hasAllGrain: boolean;
+}
+
+export interface BardTableMetadata extends TableMetadata {
+  timeGrains: TimeGrain[];
+  hasAllGrain: boolean;
+}
+
+export const GrainOrdering: Record<Grain, number> = {
+  second: 1,
+  minute: 2,
+  hour: 3,
+  day: 4,
+  week: 5,
+  isoWeek: 5,
+  month: 6,
+  quarter: 7,
+  year: 8
+};
+
+export default class BardTableMetadataModel extends TableMetadataModel implements BardTableMetadataModel {
+  init() {
+    //@ts-ignore
+    super.init(...arguments);
+    this.timeGrainIds = sortBy(this.timeGrainIds, g => GrainOrdering[g]);
+  }
+
+  /**
+   * @property timeGrainIds - supported timegrains for the table
+   */
+  timeGrainIds: Grain[] = [];
+
+  /**
+   * @property timeGrains - timeGrain objects with id and display name
+   */
+  get timeGrains(): TimeGrain[] {
+    return this.timeGrainIds.map(grain => ({ id: grain, name: upperFirst(grain) }));
+  }
+
+  /**
+   * @property hasAllGrain - whether or not this table supports 'all' grain
+   */
+  hasAllGrain!: boolean;
+}

--- a/packages/data/addon/models/metadata/table.ts
+++ b/packages/data/addon/models/metadata/table.ts
@@ -4,17 +4,11 @@
  */
 import EmberObject from '@ember/object';
 import { inject as service } from '@ember/service';
-import { upperFirst } from 'lodash-es';
 import MetricMetadataModel from './metric';
 import DimensionMetadataModel from './dimension';
 import TimeDimensionMetadataModel from './time-dimension';
 import CARDINALITY_SIZES from '../../utils/enums/cardinality-sizes';
 import NaviMetadataService from 'navi-data/services/navi-metadata';
-
-export type TimeGrain = {
-  id: string;
-  name: string;
-};
 
 // Shape passed to model constructor
 export interface TableMetadataPayload {
@@ -28,7 +22,6 @@ export interface TableMetadataPayload {
   dimensionIds: string[];
   timeDimensionIds: string[];
   source: string;
-  timeGrainIds?: string[];
   tags?: string[];
 }
 // Shape of public properties on model
@@ -43,7 +36,6 @@ export interface TableMetadata {
   dimensions: DimensionMetadataModel[];
   timeDimensions: TimeDimensionMetadataModel[];
   source: string;
-  timeGrains: TimeGrain[];
   tags: string[];
 }
 
@@ -138,23 +130,6 @@ export default class TableMetadataModel extends EmberObject implements TableMeta
    * @property {string} source - the datasource this metadata is from.
    */
   source!: string;
-
-  /**
-   * @property {string[]} timeGrainIds - supported timegrains for a column
-   */
-  timeGrainIds: string[] = [];
-
-  /**
-   * @property {Object[]} timeGrains - timeGrain objects with id and display name
-   */
-  get timeGrains(): TimeGrain[] {
-    return this.timeGrainIds.map(grain => {
-      return {
-        id: grain,
-        name: upperFirst(grain)
-      };
-    });
-  }
 }
 
 declare module './registry' {

--- a/packages/data/addon/models/navi-fact-response.ts
+++ b/packages/data/addon/models/navi-fact-response.ts
@@ -33,7 +33,7 @@ export default class NaviFactResponse extends EmberObject implements ResponseV1 
     const moments = rows
       .map(row => {
         const value = row[field];
-        return value ? moment(value as MomentInput) : null;
+        return value ? moment.parseZone(value as MomentInput) : null;
       })
       .filter(notNull);
 

--- a/packages/data/addon/serializers/metadata/bard.ts
+++ b/packages/data/addon/serializers/metadata/bard.ts
@@ -323,11 +323,10 @@ export default class BardMetadataSerializer extends NaviMetadataSerializer {
     timeGrainInfo: TableTimeGrainInfo,
     dataSourceName: string
   ): ColumnFunctionMetadataModel {
-    const { hasAllGrain } = timeGrainInfo;
     const grainIds = timeGrainInfo.timeGrains.map(g => g.name);
 
     const grains = grainIds.join(',');
-    const columnFunctionId = `${this.namespace}:timeGrain(table=${table.name};grains=${grains};hasAllGrain=${hasAllGrain})`;
+    const columnFunctionId = `${this.namespace}:timeGrain(table=${table.name};grains=${grains})`;
     let defaultValue;
     const { defaultTimeGrain } = config.navi;
     if (defaultTimeGrain && grainIds.includes(defaultTimeGrain)) {
@@ -349,13 +348,11 @@ export default class BardMetadataSerializer extends NaviMetadataSerializer {
           type: 'ref',
           expression: INTRINSIC_VALUE_EXPRESSION,
           defaultValue,
-          _localValues: table.timeGrains
-            .filter(({ name }) => name !== 'all')
-            .map(grain => ({
-              id: this.normalizeTimeGrain(grain.name),
-              description: grain.description,
-              name: grain.longName
-            }))
+          _localValues: timeGrainInfo.timeGrains.map(grain => ({
+            id: grain.name,
+            description: grain.description,
+            name: grain.longName
+          }))
         }
       ]
     };

--- a/packages/data/addon/utils/date.ts
+++ b/packages/data/addon/utils/date.ts
@@ -15,16 +15,12 @@ export const CAL_DISPLAY_DATE_FORMAT_STRING = 'M/D/YYYY';
 
 export type DateTimePeriod = 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year';
 type StandardGrain = DateTimePeriod | 'isoWeek';
-export type Grain = StandardGrain | 'all';
+export type Grain = StandardGrain;
 
 /**
  * Returns a date time period for a gain
  */
 export function getPeriodForGrain(grain: Grain): DateTimePeriod {
-  if ('all' === grain) {
-    return 'day';
-  }
-
   if ('isoWeek' === grain) {
     return 'week';
   }

--- a/packages/data/addon/utils/date.ts
+++ b/packages/data/addon/utils/date.ts
@@ -13,9 +13,14 @@ export const PARAM_DATE_FORMAT_STRING = 'YYYY-MM-DD';
 export const CAL_DATE_FORMAT_STRING = 'MM-DD-YYYY';
 export const CAL_DISPLAY_DATE_FORMAT_STRING = 'M/D/YYYY';
 
-export type DateTimePeriod = 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year';
-type StandardGrain = DateTimePeriod | 'isoWeek';
-export type Grain = StandardGrain;
+const weekDown = <const>['second', 'minute', 'hour', 'day', 'week'];
+const monthUp = <const>['month', 'quarter', 'year'];
+
+export const DateTimePeriods = <const>[...weekDown, ...monthUp];
+export const Grains = <const>[...weekDown, 'isoWeek', ...monthUp];
+
+export type DateTimePeriod = typeof DateTimePeriods[number];
+export type Grain = typeof Grains[number];
 
 /**
  * Returns a date time period for a gain
@@ -30,7 +35,7 @@ export function getPeriodForGrain(grain: Grain): DateTimePeriod {
 /**
  * Returns the epoch date at the start of the given grain
  */
-export function getFirstDayEpochForGrain(grain: StandardGrain, dateFormat: string = API_DATE_FORMAT_STRING): string {
+export function getFirstDayEpochForGrain(grain: Grain, dateFormat: string = API_DATE_FORMAT_STRING): string {
   const period = getPeriodForGrain(grain);
   const epochDate = moment(config.navi.dataEpoch, EPOCH_FORMAT_STRING);
 
@@ -44,11 +49,7 @@ export function getFirstDayEpochForGrain(grain: StandardGrain, dateFormat: strin
 /**
  * Returns last day of grain for a given date
  */
-export function getLastDayOfGrain(
-  date: Moment,
-  grain: StandardGrain,
-  dateFormat: string = API_DATE_FORMAT_STRING
-): string {
+export function getLastDayOfGrain(date: Moment, grain: Grain, dateFormat: string = API_DATE_FORMAT_STRING): string {
   return moment(date)
     .endOf(grain)
     .format(dateFormat);
@@ -57,11 +58,7 @@ export function getLastDayOfGrain(
 /**
  * Returns first day of grain for a given date
  */
-export function getFirstDayOfGrain(
-  date: Moment,
-  grain: StandardGrain,
-  dateFormat: string = API_DATE_FORMAT_STRING
-): string {
+export function getFirstDayOfGrain(date: Moment, grain: Grain, dateFormat: string = API_DATE_FORMAT_STRING): string {
   return moment(date)
     .startOf(grain)
     .format(dateFormat);

--- a/packages/data/app/models/metadata/bard/table.js
+++ b/packages/data/app/models/metadata/bard/table.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-data/models/metadata/bard/table';

--- a/packages/data/tests/unit/adapters/facts/bard-test.ts
+++ b/packages/data/tests/unit/adapters/facts/bard-test.ts
@@ -728,8 +728,8 @@ module('Unit | Adapter | facts/bard', function(hooks) {
       () => {
         Adapter._buildURLPath(twoDateTime);
       },
-      /FactAdapterError: Requesting more than multiple 'Date Time' grains is not supported. You requested \[day,week\]/,
-      '_buildURLPath throws an error when more than one dateTime column is requested'
+      /FactAdapterError: Requesting multiple 'Date Time' grains is not supported. You requested \[day,week\]/,
+      '_buildURLPath throws an error when more than one grain is requested'
     );
 
     assert.equal(

--- a/packages/data/tests/unit/adapters/facts/bard-test.ts
+++ b/packages/data/tests/unit/adapters/facts/bard-test.ts
@@ -5,6 +5,7 @@ import config from 'ember-get-config';
 import { RequestV2 } from 'navi-data/adapters/facts/interface';
 import BardFactsAdapter from 'navi-data/adapters/facts/bard';
 import { TestContext } from 'ember-test-helpers';
+import MetadataModelRegistry from 'navi-data/models/metadata/registry';
 
 const HOST = config.navi.dataSources[0].uri;
 const HOST2 = config.navi.dataSources[1].uri;
@@ -233,7 +234,7 @@ module('Unit | Adapter | facts/bard', function(hooks) {
         {
           field: 'tableName.dateTime',
           type: 'timeDimension',
-          parameters: { grain: 'all' },
+          parameters: { grain: 'day' },
           operator: 'bet',
           values: ['start', 'end']
         }
@@ -281,7 +282,7 @@ module('Unit | Adapter | facts/bard', function(hooks) {
       () => {
         Adapter._buildDateTimeParam(noIntervals);
       },
-      /Exactly one '.dateTime' filter is supported, you have 0/,
+      /Exactly one '.dateTime' filter is required, you have 0/,
       '_buildDateTimeParam throws an error for missing dateTime filter'
     );
 
@@ -309,7 +310,7 @@ module('Unit | Adapter | facts/bard', function(hooks) {
       () => {
         Adapter._buildDateTimeParam(manyIntervals);
       },
-      /Exactly one 'tableName.dateTime' filter is supported, you have 2/,
+      /Exactly one 'tableName.dateTime' filter is required, you have 2/,
       '_buildDateTimeParam throws an error for multiple datetime filters'
     );
   });
@@ -675,27 +676,59 @@ module('Unit | Adapter | facts/bard', function(hooks) {
   });
 
   test('_buildURLPath', function(assert) {
-    assert.expect(4);
+    assert.expect(6);
 
     assert.equal(
-      Adapter._buildURLPath({ ...EmptyRequest, table: 'tableName' }),
+      Adapter._buildURLPath({ ...EmptyRequest, table: 'tableName', dataSource: 'bardOne' }),
       'https://data.naviapp.io/v1/data/tableName/all/',
-      '_buildURLPath throws an error for missing dateTime column'
+      '_buildURLPath assumes the all timeGrain exists if table metadata is not loaded'
     );
+
+    const originalNaviMetadata = Adapter.naviMetadata;
+    //@ts-ignore
+    Adapter.naviMetadata = {
+      getById<K extends keyof MetadataModelRegistry>(
+        _type: K,
+        _id: string,
+        _dataSourceName: string
+      ): MetadataModelRegistry[K] {
+        return ({ hasAllGrain: false } as unknown) as MetadataModelRegistry[K];
+      }
+    };
+    assert.throws(
+      () => {
+        Adapter._buildURLPath({ ...EmptyRequest, table: 'tableName', dataSource: 'bardOne' });
+      },
+      /Table 'tableName' requires exactly 1 'Date Time' column, you have 0./,
+      '_buildURLPath throws an error for missing dateTime column for table without all grain'
+    );
+
+    assert.equal(
+      Adapter._buildURLPath({
+        ...EmptyRequest,
+        table: 'tableName',
+        dataSource: 'bardOne',
+        columns: [{ type: 'timeDimension', field: 'tableName.dateTime', parameters: { grain: 'grain' } }]
+      }),
+      'https://data.naviapp.io/v1/data/tableName/grain/',
+      '_buildURLPath does not throw error for table without all grain that specifies a grain to use'
+    );
+    Adapter.naviMetadata = originalNaviMetadata;
 
     const twoDateTime: RequestV2 = {
       ...EmptyRequest,
       columns: [
-        { field: '.dateTime', type: 'timeDimension', parameters: { grain: 'all' } },
+        { field: '.dateTime', type: 'timeDimension', parameters: { grain: 'day' } },
         { field: '.dateTime', type: 'timeDimension', parameters: { grain: 'week' } }
-      ]
+      ],
+      dataSource: 'bardOne'
     };
 
     assert.throws(
       () => {
         Adapter._buildURLPath(twoDateTime);
       },
-      /Requsting more than one '.dateTime' columns is not supported/,
+      /FactAdapterError: Requesting more than one '.dateTime' grain is not supported. You requested \[day,week\]/,
       '_buildURLPath throws an error when more than one dateTime column is requested'
     );
 

--- a/packages/data/tests/unit/adapters/facts/bard-test.ts
+++ b/packages/data/tests/unit/adapters/facts/bard-test.ts
@@ -699,7 +699,7 @@ module('Unit | Adapter | facts/bard', function(hooks) {
       () => {
         Adapter._buildURLPath({ ...EmptyRequest, table: 'tableName', dataSource: 'bardOne' });
       },
-      /Table 'tableName' requires exactly 1 'Date Time' column, you have 0./,
+      /FactAdapterError: Table 'tableName' requires requesting 'Date Time' column exactly once./,
       '_buildURLPath throws an error for missing dateTime column for table without all grain'
     );
 
@@ -728,7 +728,7 @@ module('Unit | Adapter | facts/bard', function(hooks) {
       () => {
         Adapter._buildURLPath(twoDateTime);
       },
-      /FactAdapterError: Requesting more than one '.dateTime' grain is not supported. You requested \[day,week\]/,
+      /FactAdapterError: Requesting more than multiple 'Date Time' grains is not supported. You requested \[day,week\]/,
       '_buildURLPath throws an error when more than one dateTime column is requested'
     );
 

--- a/packages/data/tests/unit/models/metadata/bard/table-test.ts
+++ b/packages/data/tests/unit/models/metadata/bard/table-test.ts
@@ -1,0 +1,59 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import BardTableMetadataModel from 'navi-data/models/metadata/bard/table';
+import { BardTableMetadataPayload } from 'navi-data/models/metadata/bard/table';
+
+let Payload: BardTableMetadataPayload, Model: BardTableMetadataModel;
+
+module('Unit | Model | metadata/bard/table', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    Payload = {
+      id: 'tableA',
+      name: 'Table A',
+      description: 'Table A',
+      category: 'table',
+      cardinality: 'LARGE',
+      metricIds: ['pv'],
+      isFact: true,
+      dimensionIds: ['age'],
+      timeDimensionIds: ['orderDate'],
+      timeGrainIds: ['day', 'month', 'week'],
+      hasAllGrain: false,
+      source: 'bardOne',
+      tags: ['DISPLAY']
+    };
+
+    Model = BardTableMetadataModel.create(Payload);
+  });
+
+  test('it properly hydrates properties', function(assert) {
+    assert.expect(1);
+
+    assert.deepEqual(Model.timeGrainIds, ['day', 'week', 'month'], 'timeGrainIds property is hydrated properly');
+  });
+
+  test('it returns timegrains', function(assert) {
+    assert.expect(1);
+
+    assert.deepEqual(
+      Model.timeGrains,
+      [
+        {
+          id: 'day',
+          name: 'Day'
+        },
+        {
+          id: 'week',
+          name: 'Week'
+        },
+        {
+          id: 'month',
+          name: 'Month'
+        }
+      ],
+      'isFact property is hydrated properly'
+    );
+  });
+});

--- a/packages/data/tests/unit/models/metadata/bard/table-test.ts
+++ b/packages/data/tests/unit/models/metadata/bard/table-test.ts
@@ -53,7 +53,7 @@ module('Unit | Model | metadata/bard/table', function(hooks) {
           name: 'Month'
         }
       ],
-      'isFact property is hydrated properly'
+      'timegrains property is hydrated properly'
     );
   });
 });

--- a/packages/data/tests/unit/models/metadata/table-test.js
+++ b/packages/data/tests/unit/models/metadata/table-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { run } from '@ember/runloop';
 
 let Payload, Model, Keg, TableFactory;
 
@@ -17,12 +16,12 @@ module('Unit | Metadata Model | Table', function(hooks) {
       metricIds: ['pv'],
       dimensionIds: ['age'],
       timeDimensionIds: ['orderDate'],
-      timeGrainIds: ['day', 'month', 'week'],
+      isFact: true,
       source: 'bardOne',
       tags: ['DISPLAY']
     };
 
-    Model = run(() => this.owner.factoryFor('model:metadata/table').create(Payload));
+    Model = this.owner.factoryFor('model:metadata/table').create(Payload);
 
     //Looking up and injecting keg into the model
     Keg = this.owner.lookup('service:keg');
@@ -83,7 +82,7 @@ module('Unit | Metadata Model | Table', function(hooks) {
       dimensionIds,
       timeDimensionIds,
       source,
-      timeGrainIds,
+      isFact,
       tags
     } = Model;
 
@@ -97,7 +96,7 @@ module('Unit | Metadata Model | Table', function(hooks) {
     assert.deepEqual(timeDimensionIds, Payload.timeDimensionIds, 'timeDimensionIds property is hydrated properly');
     assert.equal(source, Payload.source, 'source property is hydrated properly');
     assert.deepEqual(tags, Payload.tags, 'tags property is hydrated properly');
-    assert.deepEqual(timeGrainIds, Payload.timeGrainIds, 'timeGrainIds property is hydrated properly');
+    assert.deepEqual(isFact, Payload.isFact, 'isFact property is hydrated properly');
   });
 
   test('Metric in Table', function(assert) {

--- a/packages/data/tests/unit/models/navi-fact-response-test.ts
+++ b/packages/data/tests/unit/models/navi-fact-response-test.ts
@@ -85,7 +85,7 @@ module('Unit | Model | navi fact response', function(hooks) {
     ) as TimeDimensionMetadataModel;
     const max = response.getMaxTimeDimension({ columnMetadata });
     assert.ok(
-      moment(rows[2]['table1.eventTimeDay']).isSame(max),
+      moment.parseZone(rows[2]['table1.eventTimeDay']).isSame(max),
       '`getMaxTimeDimension` returns the max dateTime for a column in moment form'
     );
   });
@@ -104,7 +104,7 @@ module('Unit | Model | navi fact response', function(hooks) {
     ) as TimeDimensionMetadataModel;
     const min = response.getMinTimeDimension({ columnMetadata });
     assert.ok(
-      moment(rows[0]['table1.eventTimeDay']).isSame(min),
+      moment.parseZone(rows[0]['table1.eventTimeDay']).isSame(min),
       '`getMinTimeDimension` returns the min dateTime for a column in moment form'
     );
   });
@@ -158,7 +158,7 @@ module('Unit | Model | navi fact response', function(hooks) {
     const maxResponse = NaviFactResponse.create({ rows: maxRows });
     const max = maxResponse.getMaxTimeDimension({ columnMetadata });
     assert.ok(
-      moment(maxRows[2]['table1.eventTimeDay']).isSame(max),
+      moment.parseZone(maxRows[2]['table1.eventTimeDay']).isSame(max),
       '`getMaxTimeDimension` returns max dateTime when date values have gaps'
     );
 
@@ -171,7 +171,7 @@ module('Unit | Model | navi fact response', function(hooks) {
 
     const min = minResponse.getMinTimeDimension({ columnMetadata });
     assert.ok(
-      moment(minRows[2]['table1.eventTimeDay']).isSame(min),
+      moment.parseZone(minRows[2]['table1.eventTimeDay']).isSame(min),
       '`getMinTimeDimension` returns min dateTime when date values have gaps'
     );
   });
@@ -216,8 +216,8 @@ module('Unit | Model | navi fact response', function(hooks) {
     assert.deepEqual(
       interval?.asStrings(),
       {
-        start: '2014-04-02 00:00:00.000',
-        end: '2014-04-04 00:00:00.000'
+        start: '2014-04-02T00:00:00.000Z',
+        end: '2014-04-04T00:00:00.000Z'
       },
       '`getIntervalForTimeDimension` returns an `Interval` object for a time dimension column'
     );

--- a/packages/data/tests/unit/serializers/metadata/bard-test.ts
+++ b/packages/data/tests/unit/serializers/metadata/bard-test.ts
@@ -478,7 +478,7 @@ const TimeDimensionPayloads: TimeDimensionMetadataPayload[] = [
   },
   {
     category: 'Date',
-    columnFunctionId: 'normalizer-generated:timeGrain(table=tableName;grains=day,month;hasAllGrain=true)',
+    columnFunctionId: 'normalizer-generated:timeGrain(table=tableName;grains=day,month)',
     description: undefined,
     fields: undefined,
     id: 'tableName.dateTime',
@@ -502,7 +502,7 @@ const TimeDimensionPayloads: TimeDimensionMetadataPayload[] = [
   },
   {
     category: 'Date',
-    columnFunctionId: 'normalizer-generated:timeGrain(table=secondTable;grains=day,isoWeek;hasAllGrain=false)',
+    columnFunctionId: 'normalizer-generated:timeGrain(table=secondTable;grains=day,isoWeek)',
     description: undefined,
     fields: undefined,
     id: 'secondTable.dateTime',
@@ -709,7 +709,7 @@ const ColumnFunctionPayloads: ColumnFunctionMetadataPayload[] = [
     source: 'bardOne'
   },
   {
-    id: 'normalizer-generated:timeGrain(table=tableName;grains=day,month;hasAllGrain=true)',
+    id: 'normalizer-generated:timeGrain(table=tableName;grains=day,month)',
     name: 'Time Grain',
     description: 'Time Grain',
     source: 'bardOne',
@@ -730,7 +730,7 @@ const ColumnFunctionPayloads: ColumnFunctionMetadataPayload[] = [
     ]
   },
   {
-    id: 'normalizer-generated:timeGrain(table=secondTable;grains=day,isoWeek;hasAllGrain=false)',
+    id: 'normalizer-generated:timeGrain(table=secondTable;grains=day,isoWeek)',
     name: 'Time Grain',
     description: 'Time Grain',
     source: 'bardOne',
@@ -906,7 +906,7 @@ module('Unit | Serializer | metadata/bard', function(hooks) {
       },
       {
         description: 'Time Grain',
-        id: 'normalizer-generated:timeGrain(table=tableName;grains=day;hasAllGrain=false)',
+        id: 'normalizer-generated:timeGrain(table=tableName;grains=day)',
         name: 'Time Grain',
         source: 'bardOne',
         _parametersPayload: [

--- a/packages/data/tests/unit/serializers/metadata/bard-test.ts
+++ b/packages/data/tests/unit/serializers/metadata/bard-test.ts
@@ -8,11 +8,11 @@ import BardMetadataSerializer, {
   RawMetricPayload,
   RawTablePayload
 } from 'navi-data/serializers/metadata/bard';
-import TableMetadataModel, { TableMetadataPayload } from 'navi-data/models/metadata/table';
 import DimensionMetadataModel, { DimensionMetadataPayload } from 'navi-data/models/metadata/dimension';
 import TimeDimensionMetadataModel, { TimeDimensionMetadataPayload } from 'navi-data/models/metadata/time-dimension';
 import MetricMetadataModel, { MetricMetadataPayload } from 'navi-data/models/metadata/metric';
 import ColumnFunctionMetadataModel, { ColumnFunctionMetadataPayload } from 'navi-data/models/metadata/column-function';
+import BardTableMetadataModel, { BardTableMetadataPayload } from 'navi-data/models/metadata/bard/table';
 
 const Payload: RawEverythingPayload = {
   tables: [
@@ -22,6 +22,83 @@ const Payload: RawEverythingPayload = {
       longName: 'tableLongName',
       category: 'General',
       timeGrains: [
+        {
+          name: 'all',
+          description: 'The tableName all grain',
+          metrics: [
+            {
+              category: 'category',
+              name: 'metricOne',
+              longName: 'Metric One',
+              type: 'number'
+            },
+            {
+              category: 'category',
+              name: 'metricFour',
+              longName: 'Metric Four',
+              type: 'money',
+              parameters: {
+                currency: {
+                  type: 'dimension',
+                  dimensionName: 'displayCurrency',
+                  defaultValue: 'USD'
+                },
+                format: {
+                  type: 'dimension',
+                  dimensionName: 'displayFormat',
+                  defaultValue: 'none'
+                }
+              }
+            }
+          ],
+          retention: 'P24M',
+          longName: 'All',
+          dimensions: [
+            {
+              category: 'categoryOne',
+              name: 'dimensionOne',
+              longName: 'Dimension One',
+              cardinality: 10,
+              datatype: 'text',
+              fields: [
+                {
+                  name: 'id',
+                  description: 'Dimension ID'
+                },
+                {
+                  name: 'desc',
+                  description: 'Dimension Description'
+                }
+              ]
+            },
+            {
+              category: 'categoryTwo',
+              name: 'dimensionTwo',
+              longName: 'Dimension Two',
+              cardinality: 5,
+              datatype: 'text',
+              fields: [
+                {
+                  name: 'foo',
+                  description: 'bar'
+                }
+              ]
+            },
+            {
+              category: 'dateCategory',
+              name: 'dimensionThree',
+              longName: 'Dimension Three',
+              cardinality: 50000,
+              datatype: 'date',
+              fields: [
+                {
+                  name: 'id',
+                  description: 'Dimension ID'
+                }
+              ]
+            }
+          ]
+        },
         {
           name: 'day',
           description: 'The tableName day grain',
@@ -295,7 +372,7 @@ const Payload: RawEverythingPayload = {
   ]
 };
 // list of table objects, with table->timegrains->dimensions+metrics
-const TablePayloads: TableMetadataPayload[] = [
+const TablePayloads: BardTableMetadataPayload[] = [
   {
     cardinality: 'MEDIUM',
     isFact: true,
@@ -307,7 +384,8 @@ const TablePayloads: TableMetadataPayload[] = [
     name: 'tableLongName',
     source: 'bardOne',
     timeDimensionIds: ['dimensionThree', 'tableName.dateTime'],
-    timeGrainIds: ['day', 'month']
+    timeGrainIds: ['day', 'month'],
+    hasAllGrain: true
   },
   {
     cardinality: 'MEDIUM',
@@ -320,7 +398,8 @@ const TablePayloads: TableMetadataPayload[] = [
     name: 'Second Table',
     source: 'bardOne',
     timeDimensionIds: ['dimensionThree', 'secondTable.dateTime'],
-    timeGrainIds: ['day', 'week']
+    timeGrainIds: ['day', 'isoWeek'],
+    hasAllGrain: false
   }
 ];
 
@@ -399,7 +478,7 @@ const TimeDimensionPayloads: TimeDimensionMetadataPayload[] = [
   },
   {
     category: 'Date',
-    columnFunctionId: 'normalizer-generated:timeGrain(table=tableName;grains=day,month)',
+    columnFunctionId: 'normalizer-generated:timeGrain(table=tableName;grains=day,month;hasAllGrain=true)',
     description: undefined,
     fields: undefined,
     id: 'tableName.dateTime',
@@ -423,7 +502,7 @@ const TimeDimensionPayloads: TimeDimensionMetadataPayload[] = [
   },
   {
     category: 'Date',
-    columnFunctionId: 'normalizer-generated:timeGrain(table=secondTable;grains=day,isoWeek)',
+    columnFunctionId: 'normalizer-generated:timeGrain(table=secondTable;grains=day,isoWeek;hasAllGrain=false)',
     description: undefined,
     fields: undefined,
     id: 'secondTable.dateTime',
@@ -437,7 +516,7 @@ const TimeDimensionPayloads: TimeDimensionMetadataPayload[] = [
       },
       {
         expression: '',
-        grain: 'Week',
+        grain: 'IsoWeek',
         id: 'isoWeek'
       }
     ],
@@ -630,7 +709,7 @@ const ColumnFunctionPayloads: ColumnFunctionMetadataPayload[] = [
     source: 'bardOne'
   },
   {
-    id: 'normalizer-generated:timeGrain(table=tableName;grains=day,month)',
+    id: 'normalizer-generated:timeGrain(table=tableName;grains=day,month;hasAllGrain=true)',
     name: 'Time Grain',
     description: 'Time Grain',
     source: 'bardOne',
@@ -651,7 +730,7 @@ const ColumnFunctionPayloads: ColumnFunctionMetadataPayload[] = [
     ]
   },
   {
-    id: 'normalizer-generated:timeGrain(table=secondTable;grains=day,isoWeek)',
+    id: 'normalizer-generated:timeGrain(table=secondTable;grains=day,isoWeek;hasAllGrain=false)',
     name: 'Time Grain',
     description: 'Time Grain',
     source: 'bardOne',
@@ -686,14 +765,14 @@ let ColumnFunctions: ColumnFunctionMetadataModel[];
 let Metrics: MetricMetadataModel[];
 let TimeDimensions: TimeDimensionMetadataModel[];
 let Dimensions: DimensionMetadataModel[];
-let Tables: TableMetadataModel[];
+let Tables: BardTableMetadataModel[];
 
 module('Unit | Serializer | metadata/bard', function(hooks) {
   setupTest(hooks);
 
   hooks.beforeEach(function(this: TestContext) {
     Serializer = this.owner.lookup('serializer:metadata/bard');
-    Tables = TablePayloads.map(p => TableMetadataModel.create(this.owner.ownerInjection(), p));
+    Tables = TablePayloads.map(p => BardTableMetadataModel.create(this.owner.ownerInjection(), p));
     Dimensions = DimensionsPayloads.map(p => DimensionMetadataModel.create(this.owner.ownerInjection(), p));
     TimeDimensions = TimeDimensionPayloads.map(p => TimeDimensionMetadataModel.create(this.owner.ownerInjection(), p));
     Metrics = MetricPayloads.map(p => MetricMetadataModel.create(this.owner.ownerInjection(), p));
@@ -827,7 +906,7 @@ module('Unit | Serializer | metadata/bard', function(hooks) {
       },
       {
         description: 'Time Grain',
-        id: 'normalizer-generated:timeGrain(table=tableName;grains=day)',
+        id: 'normalizer-generated:timeGrain(table=tableName;grains=day;hasAllGrain=false)',
         name: 'Time Grain',
         source: 'bardOne',
         _parametersPayload: [
@@ -943,15 +1022,16 @@ module('Unit | Serializer | metadata/bard', function(hooks) {
     };
 
     config.navi.defaultTimeGrain = 'isoWeek';
-    let columnFunction = Serializer['createTimeGrainColumnFunction'](table, 'bardOne');
+    const tableGrainInfo = Serializer['parseTableGrains'](table);
+    let columnFunction = Serializer['createTimeGrainColumnFunction'](table, tableGrainInfo, 'bardOne');
     assert.equal(columnFunction._parametersPayload?.[0].defaultValue, 'isoWeek', 'Picks default from config');
 
     config.navi.defaultTimeGrain = 'year';
-    columnFunction = Serializer['createTimeGrainColumnFunction'](table, 'bardOne');
-    assert.equal(columnFunction._parametersPayload?.[0].defaultValue, 'day', 'Falls back to first defined grain');
+    columnFunction = Serializer['createTimeGrainColumnFunction'](table, tableGrainInfo, 'bardOne');
+    assert.equal(columnFunction._parametersPayload?.[0].defaultValue, 'hour', 'Falls back to first defined grain');
 
     config.navi.defaultTimeGrain = 'hour';
-    columnFunction = Serializer['createTimeGrainColumnFunction'](table, 'bardOne');
+    columnFunction = Serializer['createTimeGrainColumnFunction'](table, tableGrainInfo, 'bardOne');
     assert.equal(columnFunction._parametersPayload?.[0].defaultValue, 'hour', 'Picks default from config');
 
     config.navi.defaultTimeGrain = originalDefaultTimeGrain;

--- a/packages/data/tests/unit/services/navi-facts-elide-test.ts
+++ b/packages/data/tests/unit/services/navi-facts-elide-test.ts
@@ -443,7 +443,8 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
               field: 'table1.eventTimeDay',
               operator: 'gte',
               values: [
-                moment()
+                moment
+                  .utc()
                   .subtract(2, 'days')
                   .format(DAY_FORMAT)
               ],
@@ -469,16 +470,20 @@ module('Unit | Service | Navi Facts - Elide', function(hooks) {
         rows: [
           {
             'table1.eventTimeDay': moment()
+              .utc()
               .subtract(2, 'days')
               .format(DAY_FORMAT)
           },
           {
             'table1.eventTimeDay': moment()
+              .utc()
               .subtract(1, 'days')
               .format(DAY_FORMAT)
           },
           {
-            'table1.eventTimeDay': moment().format(DAY_FORMAT)
+            'table1.eventTimeDay': moment()
+              .utc()
+              .format(DAY_FORMAT)
           }
         ],
         meta: {}

--- a/packages/data/tests/unit/services/navi-facts-test.ts
+++ b/packages/data/tests/unit/services/navi-facts-test.ts
@@ -220,7 +220,7 @@ module('Unit | Service | Navi Facts', function(hooks) {
       assert.ok(true, 'A request error falls into the promise catch block');
       assert.equal(
         response.details[0],
-        `Exactly one 'table1.dateTime' filter is supported, you have 0`,
+        `Exactly one 'table1.dateTime' filter is required, you have 0`,
         'Adapter error is shown'
       );
     });

--- a/packages/data/tests/unit/utils/classes/interval-test.ts
+++ b/packages/data/tests/unit/utils/classes/interval-test.ts
@@ -71,7 +71,7 @@ module('Unit | Utils | Interval Class', function() {
   });
 
   test('diffForTimePeriod', function(assert) {
-    assert.expect(8);
+    assert.expect(6);
 
     assert.equal(
       new Interval(new Duration('P7D'), 'current').diffForTimePeriod('day'),
@@ -108,22 +108,10 @@ module('Unit | Utils | Interval Class', function() {
       1,
       'Interval has 1 hour for a 1 hour period'
     );
-
-    assert.equal(
-      new Interval(moment('2015-11-10 10:00:00.000'), moment('2015-11-10 11:00:00.000')).diffForTimePeriod('all'),
-      1,
-      "Interval has 'all' timeGrain and 1 time bucket for 1 hour timePeriod"
-    );
-
-    assert.equal(
-      new Interval(moment('2015-11-10 10:00:00.000'), moment('2015-11-13 11:00:00.000')).diffForTimePeriod('all'),
-      1,
-      "Interval has 'all' timeGrain and 1 time bucket for all timePeriod multiple time buckets"
-    );
   });
 
   test('getDatesForInterval', function(assert) {
-    assert.expect(2);
+    assert.expect(1);
 
     let testInterval = new Interval(moment('4-9-2017', 'D-M-Y'), moment('25-9-2017', 'D-M-Y')),
       dates = testInterval.getDatesForInterval('isoWeek');
@@ -132,13 +120,6 @@ module('Unit | Utils | Interval Class', function() {
       dates.map(date => date.format('D-M-Y')),
       ['4-9-2017', '11-9-2017', '18-9-2017'],
       'A moment for each isoWeek between Sep 4 and Sep 25 (exclusive) is returned'
-    );
-
-    dates = testInterval.getDatesForInterval('all');
-    assert.deepEqual(
-      dates.map(date => date.format('D-M-Y')),
-      ['4-9-2017'],
-      'A moment for all time is returned as the start date'
     );
   });
 
@@ -310,7 +291,7 @@ module('Unit | Utils | Interval Class', function() {
 
     strings = new Interval(start, end).asStrings();
 
-    assert.equal(strings.start, start.format('YYYY-MM-DD HH:mm:ss.SSS'), 'Moments are formatted for API');
+    assert.equal(strings.start, start.toISOString(), 'Moments are formatted for API');
   });
 
   test('_stringFromProperty', function(assert) {
@@ -321,11 +302,7 @@ module('Unit | Utils | Interval Class', function() {
     assert.equal(Interval['_stringFromProperty']('current'), 'current', 'Macro keeps original value');
 
     let start = moment('2014-10-10', FORMAT);
-    assert.equal(
-      Interval['_stringFromProperty'](start),
-      start.format('YYYY-MM-DD HH:mm:ss.SSS'),
-      'Moments are formatted for API'
-    );
+    assert.equal(Interval['_stringFromProperty'](start), start.toISOString(), 'Moments are formatted for API');
   });
 
   test('fromString', function(assert) {

--- a/packages/data/tests/unit/utils/date-test.ts
+++ b/packages/data/tests/unit/utils/date-test.ts
@@ -224,6 +224,5 @@ module('Unit | Utils | DateUtils', function() {
     assert.equal(getPeriodForGrain('isoWeek'), 'week', '`getPeriodForGrain` returns correct period for `isoWeek`');
     assert.equal(getPeriodForGrain('month'), 'month', '`getPeriodForGrain` returns correct period for `month`');
     assert.equal(getPeriodForGrain('year'), 'year', '`getPeriodForGrain` returns correct period for `year`');
-    assert.equal(getPeriodForGrain('all'), 'day', '`getPeriodForGrain` returns correct period for `all`');
   });
 });

--- a/packages/reports/addon/components/filter-builders/time-dimension.ts
+++ b/packages/reports/addon/components/filter-builders/time-dimension.ts
@@ -77,13 +77,13 @@ export function valuesForOperator(
     const interval = Interval.parseFromStrings(startStr, endStr);
     const end = interval.asMomentsForTimePeriod(dateTimePeriod).end.utc(true);
     let intervalTimePeriod = intervalPeriodForGrain(dateTimePeriod);
-    const nonAllGrain = dateTimePeriod === 'all' ? 'day' : dateTimePeriod;
 
     let intervalValue;
     if (
       end.isSame(
-        moment()
-          .startOf(nonAllGrain)
+        moment
+          .utc()
+          .startOf(dateTimePeriod)
           .utc(true)
       )
     ) {
@@ -117,7 +117,16 @@ export function valuesForOperator(
   } else if (newOperator === OPERATORS.dateRange) {
     const interval = Interval.parseFromStrings(startStr, endStr);
     const { start, end } = interval.asMomentsForTimePeriod(dateTimePeriod);
-    return [start.utc(true).toISOString(), end.utc(true).toISOString()];
+    return [
+      start
+        .startOf('day')
+        .utc(true)
+        .toISOString(),
+      end
+        .startOf('day')
+        .utc(true)
+        .toISOString()
+    ];
   }
   warn(`No operator was found for the values '${prevValues.join(',')}'`, {
     id: 'time-dimension-filter-builder-no-operator'

--- a/packages/reports/addon/components/filter-values/time-dimension/base.ts
+++ b/packages/reports/addon/components/filter-values/time-dimension/base.ts
@@ -23,16 +23,11 @@ export default class BaseTimeDimensionFilter extends Component<TimeDimensionFilt
   @readOnly('args.filter.parameters.grain') dateTimePeriod!: Grain;
 
   /**
-   * the active dateTimePeriod which does not include 'all'
+   * the active dateTimePeriod
    */
   @computed('dateTimePeriod')
   get calendarDateTimePeriod() {
-    const { dateTimePeriod } = this;
-    if (dateTimePeriod === 'all') {
-      // TODO: Handle all timegrain better
-      return 'day';
-    }
-    return dateTimePeriod;
+    return this.dateTimePeriod;
   }
 
   /**

--- a/packages/reports/addon/consumers/request/column.ts
+++ b/packages/reports/addon/consumers/request/column.ts
@@ -38,7 +38,7 @@ export default class ColumnConsumer extends ActionConsumer {
     },
 
     /**
-     * @action DID_ADD_COLUMN_
+     * @action DID_ADD_COLUMN
      * @param route - route that has a model that contains a request property
      * @param column - column fragment
      */

--- a/packages/reports/addon/consumers/request/fili.ts
+++ b/packages/reports/addon/consumers/request/fili.ts
@@ -35,9 +35,8 @@ export default class FiliConsumer extends ActionConsumer {
     /**
      * @action UPDATE_COLUMN_FRAGMENT_WITH_PARAMS
      * @param route - route that has a model that contains a request property
-     * @param columnFragment - data model fragment of the column
-     * @param parameterKey - the name of the parameter to update
-     * @param parameterValue - the value to update the parameter with
+     * @param filterFragment - data model fragment of the filter
+     * @param changeset - the filter properties to update
      */
     [RequestActions.UPDATE_FILTER](
       this: FiliConsumer,

--- a/packages/reports/addon/consumers/request/fili.ts
+++ b/packages/reports/addon/consumers/request/fili.ts
@@ -3,6 +3,7 @@
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import { inject as service } from '@ember/service';
+import { assert } from '@ember/debug';
 import ActionConsumer from 'navi-core/consumers/action-consumer';
 import Route from '@ember/routing/route';
 import RequestActionDispatcher, { RequestActions } from 'navi-reports/services/request-action-dispatcher';
@@ -13,6 +14,8 @@ import DimensionMetadataModel from 'navi-data/models/metadata/dimension';
 import { Parameters } from 'navi-data/adapters/facts/interface';
 import { valuesForOperator } from 'navi-reports/components/filter-builders/time-dimension';
 import { Grain } from 'navi-data/utils/date';
+import { BardTableMetadata } from 'navi-data/models/metadata/bard/table';
+import FilterFragment from 'navi-core/models/bard-request-v2/fragments/filter';
 
 export default class FiliConsumer extends ActionConsumer {
   @service requestActionDispatcher!: RequestActionDispatcher;
@@ -36,6 +39,31 @@ export default class FiliConsumer extends ActionConsumer {
      * @param parameterKey - the name of the parameter to update
      * @param parameterValue - the value to update the parameter with
      */
+    [RequestActions.UPDATE_FILTER](
+      this: FiliConsumer,
+      route: Route,
+      filterFragment: FilterFragment,
+      changeset: Partial<FilterFragment>
+    ) {
+      const { routeName } = route;
+      const { request } = route.modelFor(routeName) as ReportModel;
+      const { dateTimeFilter } = request;
+
+      const newGrain = changeset.parameters?.grain;
+      if (dateTimeFilter === filterFragment && newGrain) {
+        const values = valuesForOperator(dateTimeFilter, newGrain as Grain);
+        const changeset = { values };
+        this.requestActionDispatcher.dispatch(RequestActions.UPDATE_FILTER, route, dateTimeFilter, changeset);
+      }
+    },
+
+    /**
+     * @action UPDATE_COLUMN_FRAGMENT_WITH_PARAMS
+     * @param route - route that has a model that contains a request property
+     * @param columnFragment - data model fragment of the column
+     * @param parameterKey - the name of the parameter to update
+     * @param parameterValue - the value to update the parameter with
+     */
     [RequestActions.UPDATE_COLUMN_FRAGMENT_WITH_PARAMS](
       this: FiliConsumer,
       route: Route,
@@ -46,11 +74,29 @@ export default class FiliConsumer extends ActionConsumer {
       const { routeName } = route;
       const { request } = route.modelFor(routeName) as ReportModel;
 
-      const { timeGrainColumn, dateTimeFilter } = request;
-      if (timeGrainColumn === columnFragment && parameterKey === 'grain' && dateTimeFilter) {
-        const values = valuesForOperator(dateTimeFilter, parameterValue as Grain);
-        const changeset = { parameters: { ...dateTimeFilter.parameters, [parameterKey]: parameterValue }, values };
-        this.requestActionDispatcher.dispatch(RequestActions.UPDATE_FILTER, route, dateTimeFilter, changeset);
+      const { dateTimeFilter } = request;
+      // If the date time grain was updated
+      if (columnFragment.type === 'timeDimension' && parameterKey === 'grain') {
+        // and there is a date time filter, update filter grain to match
+        if (dateTimeFilter && dateTimeFilter.parameters.grain !== parameterValue) {
+          const changeset = { parameters: { ...dateTimeFilter.parameters, [parameterKey]: parameterValue } };
+          this.requestActionDispatcher.dispatch(RequestActions.UPDATE_FILTER, route, dateTimeFilter, changeset);
+        }
+
+        // update all other date time grains to match
+        request.columns
+          .filter(c => c.type === 'timeDimension' && c !== columnFragment)
+          .forEach(dateTimeColumn => {
+            if (dateTimeColumn.parameters.grain !== parameterValue) {
+              this.requestActionDispatcher.dispatch(
+                RequestActions.UPDATE_COLUMN_FRAGMENT_WITH_PARAMS,
+                route,
+                dateTimeColumn,
+                'grain',
+                parameterValue
+              );
+            }
+          });
       }
     },
 
@@ -77,6 +123,56 @@ export default class FiliConsumer extends ActionConsumer {
       ) {
         const changeset = { parameters: { ...dateTimeFilter.parameters, grain: timeGrain } };
         this.requestActionDispatcher.dispatch(RequestActions.UPDATE_FILTER, route, dateTimeFilter, changeset);
+      }
+    },
+
+    /**
+     * @action DID_ADD_COLUMN
+     * @param route - route that has a model that contains a request property
+     * @param column - column fragment
+     */
+    [RequestActions.DID_ADD_COLUMN](this: FiliConsumer, route: Route, column: ColumnFragment) {
+      const { routeName } = route;
+      const { request } = route.modelFor(routeName) as ReportModel;
+
+      const { timeGrainColumn, dateTimeFilter } = request;
+      const existingGrain = dateTimeFilter?.parameters?.grain || timeGrainColumn?.parameters?.grain;
+      // if a date time column was added and there is an existing grain, update the grain to match
+      if (column.type === 'timeDimension' && existingGrain && column.parameters.grain !== existingGrain) {
+        this.requestActionDispatcher.dispatch(
+          RequestActions.UPDATE_COLUMN_FRAGMENT_WITH_PARAMS,
+          route,
+          column,
+          'grain',
+          existingGrain
+        );
+      }
+    },
+
+    /**
+     * @action REMOVE_COLUMN_FRAGMENT
+     * @param route - route that has a model that contains a request property
+     * @param columnFragment - data model fragment of the column
+     */
+    [RequestActions.REMOVE_COLUMN_FRAGMENT](this: FiliConsumer, route: Route, column: ColumnFragment) {
+      const { routeName } = route;
+      const { request } = route.modelFor(routeName) as ReportModel;
+
+      const { dateTimeFilter, tableMetadata } = request;
+      // if there are no date time columns, one was just removed, and there is a date time filter then move filter to lowest grain
+      if (
+        request.columns.filter(c => c.type === 'timeDimension').length === 0 &&
+        column.type === 'timeDimension' &&
+        dateTimeFilter
+      ) {
+        assert('request has tableMetadata available', request.tableMetadata);
+        const bardTableMetadata = (tableMetadata as unknown) as BardTableMetadata;
+        const grain = bardTableMetadata.timeGrains[0].id;
+
+        if (dateTimeFilter.parameters.grain !== grain) {
+          const changeset = { parameters: { ...dateTimeFilter.parameters, grain } };
+          this.requestActionDispatcher.dispatch(RequestActions.UPDATE_FILTER, route, dateTimeFilter, changeset);
+        }
       }
     }
   };

--- a/packages/reports/addon/templates/components/navi-date-picker.hbs
+++ b/packages/reports/addon/templates/components/navi-date-picker.hbs
@@ -6,7 +6,7 @@
   @center={{this.centerDate}}
   @onCenterChange={{this.setCenterDate}} as |powerCalendar|
 >
-  {{#if (contains this.dateTimePeriod (w "hour day week isoWeek"))}}
+  {{#if (includes this.dateTimePeriod (w "hour day week isoWeek"))}}
     <powerCalendar.Nav>
       <span class="with-invisible-select">
         {{#with (moment-format powerCalendar.center "MMMM") as |currentMonth|}}
@@ -34,7 +34,7 @@
         {{/with}}
       </span>
     </powerCalendar.Nav>
-  {{else if (contains this.dateTimePeriod (w "month quarter"))}}
+  {{else if (includes this.dateTimePeriod (w "month quarter"))}}
     <PowerCalendarSelectorsNav @calendar={{powerCalendar}} @by="year" />
   {{else if (eq this.dateTimePeriod "year")}}
     <PowerCalendarSelectorsNav @calendar={{powerCalendar}} @by="decade" />

--- a/packages/reports/addon/utils/enums/default-intervals.js
+++ b/packages/reports/addon/utils/enums/default-intervals.js
@@ -4,7 +4,6 @@
  */
 import Interval from 'navi-data/utils/classes/interval';
 import Duration from 'navi-data/utils/classes/duration';
-import moment from 'moment';
 
 export default {
   second: 'P1D',
@@ -15,7 +14,6 @@ export default {
   month: 'P1M',
   quarter: 'P3M',
   year: 'P1Y',
-  all: 'P7D',
 
   /**
    * @method getDefault
@@ -23,11 +21,7 @@ export default {
    * @returns {Interval} default interval for given time grain
    */
   getDefault(timeGrain) {
-    // All timegrain doesn't support `current` macro
     let intervalEnd = 'current';
-    if (timeGrain === 'all') {
-      intervalEnd = moment().startOf('day');
-    }
 
     return new Interval(new Duration(this[timeGrain]), intervalEnd);
   }

--- a/packages/reports/tests/acceptance/report-test.js
+++ b/packages/reports/tests/acceptance/report-test.js
@@ -1797,12 +1797,12 @@ module('Acceptance | Navi Report', function(hooks) {
 
     await selectChoose('.filter-builder__operator-trigger', 'Current Day');
 
-    const today = moment().format('MMM DD, YYYY');
+    const today = moment.utc().format('MMM DD, YYYY');
     assert.dom('.filter-builder__values').hasText(`The current day. (${today})`, 'The current day');
   });
 
-  test('Date picker all timegrain', async function(assert) {
-    assert.expect(5);
+  test('Fili Datasource: Remove time column (all grain)', async function(assert) {
+    assert.expect(7);
 
     await visit('/reports/1');
 
@@ -1823,8 +1823,10 @@ module('Acceptance | Navi Report', function(hooks) {
       .dom('.filter-values--date-range-input__high-value input')
       .hasValue('May 2015', 'The end date is month May 2015');
 
-    // select 'all' grain
-    await selectChoose('.navi-column-config-item__parameter', 'All');
+    // Remove date time group by
+    await click('.navi-column-config-item__remove-icon[aria-label="delete time-dimension Date Time (month)"]');
+    assert.dom('.filter-builder__subject').hasText('Date Time (hour)', 'The filter grain is set to the lowest grain');
+    // TODO: Better support for hour grain
 
     assert
       .dom('.filter-values--date-range-input__low-value input')
@@ -1838,6 +1840,13 @@ module('Acceptance | Navi Report', function(hooks) {
     assert
       .dom('.filter-values--date-range-input__high-value input')
       .hasValue('May 30, 2015', 'Calendar defaults "all" grain  to show the lowest grain which is day');
+
+    await click('.navi-report__run-btn');
+    assert.deepEqual(
+      findAll('li.table-header-cell').map(el => el.textContent.trim()),
+      ['Property (id)', 'Ad Clicks', 'Nav Link Clicks'],
+      'The table is successfully queried with no Date Time group by because it supports the all grain'
+    );
   });
 
   skip("Date picker advanced doesn't modify interval", async function(assert) {

--- a/packages/reports/tests/integration/components/navi-column-config-test.js
+++ b/packages/reports/tests/integration/components/navi-column-config-test.js
@@ -139,7 +139,7 @@ module('Integration | Component | navi-column-config', function(hooks) {
       findAll('.navi-column-config-item__parameter-dropdown .ember-power-select-option').map(el =>
         el.textContent.trim()
       ),
-      ['Hour', 'Day', 'Week', 'Month', 'Quarter', 'Year', 'All'],
+      ['Hour', 'Day', 'Week', 'Month', 'Quarter', 'Year'],
       'The table time grains are passed correctly to the time grain column'
     );
 

--- a/packages/reports/tests/unit/utils/enums/default-intervals-test.js
+++ b/packages/reports/tests/unit/utils/enums/default-intervals-test.js
@@ -2,7 +2,6 @@ import DefaultIntervals from 'navi-reports/utils/enums/default-intervals';
 import { module, test } from 'qunit';
 import Interval from 'navi-data/utils/classes/interval';
 import Duration from 'navi-data/utils/classes/duration';
-import moment from 'moment';
 
 module('Unit | Utils | Enums - Default Intervals', function() {
   test('getDefault', function(assert) {
@@ -12,13 +11,5 @@ module('Unit | Utils | Enums - Default Intervals', function() {
       DefaultIntervals.getDefault('day').isEqual(new Interval(new Duration(DefaultIntervals['day']), 'current')),
       'method returns an interval between current and the default lookback for the time grain'
     );
-  });
-
-  test('getDefault - all time grain', function(assert) {
-    assert.expect(1);
-
-    let defaultInterval = DefaultIntervals.getDefault('all');
-
-    assert.ok(moment.isMoment(defaultInterval._end), 'all time grain uses the current moment, rather than the macro');
   });
 });


### PR DESCRIPTION
Resolves #1207 

## Description
The all time grain adds a lot of complexity because it's better modeled as a column that we are not grouping by

## Proposed Changes
- Remove all grain from date time parameters
- all grain is now indicated by the presence of a date time column
  - an error will be thrown if the table does not support it (only if table metadata loaded)
- Enhances the fili consumer so that timegrains can't get out of sync even with multiple date time columns
- some fixes for hour grain issues

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
