### PR TITLE
Update: Dashboards filters support no parameters

### DIFF
--- a/packages/core/addon/models/dashboard.ts
+++ b/packages/core/addon/models/dashboard.ts
@@ -18,6 +18,7 @@ import { validator, buildValidations } from 'ember-cp-validations';
 import UserModel from './user';
 import FragmentArray from 'ember-data-model-fragments/FragmentArray';
 import { Moment } from 'moment';
+import FilterFragment from './bard-request-v2/fragments/filter';
 
 const Validations = buildValidations({
   title: [
@@ -46,7 +47,7 @@ export default class DashboardModel extends DeliverableItem.extend(Validations) 
   widgets!: DS.PromiseManyArray<TODO>;
 
   @fragmentArray('bard-request-v2/fragments/filter', { defaultValue: [] })
-  filters!: FragmentArray<TODO>;
+  filters!: FragmentArray<FilterFragment>;
 
   @fragment('fragments/presentation', { defaultValue: () => ({}) })
   presentation!: TODO;

--- a/packages/core/addon/serializers/dashboard.js
+++ b/packages/core/addon/serializers/dashboard.js
@@ -6,6 +6,7 @@
 import AssetSerializer from 'navi-core/serializers/asset';
 import { getDefaultDataSourceName } from 'navi-data/utils/adapter';
 import { getOwner } from '@ember/application';
+import { canonicalizeMetric } from 'navi-data/utils/metric';
 
 function v1ToV2Filter(filter, metadataService) {
   let source;
@@ -75,7 +76,7 @@ export default AssetSerializer.extend({
    * @returns {Object} serialized dashboard
    */
   serialize(snapshot) {
-    const buildKey = filter => `${filter.field}(field=${filter.parameters.field})`;
+    const buildKey = filter => canonicalizeMetric({ metric: filter.field, parameters: filter.parameters });
     const filterSources = Object.fromEntries(
       snapshot.attr('filters').map(filter => [filter.record.canonicalName, filter.attr('source')])
     );
@@ -85,7 +86,7 @@ export default AssetSerializer.extend({
       return {
         dimension: `${source}.${filter.field}`,
         operator: filter.operator,
-        field: filter.parameters.field,
+        field: filter.parameters?.field,
         values: filter.values
       };
     });

--- a/packages/core/tests/unit/serializers/dashboard-test.js
+++ b/packages/core/tests/unit/serializers/dashboard-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { set } from '@ember/object';
 
 let Serializer, DashboardClass, MetadataService;
 
@@ -131,6 +132,15 @@ module('Unit | Serializer | dashboard', function(hooks) {
       serialized.data.attributes.filters[1],
       { dimension: 'bardTwo.container', operator: 'notin', field: 'id', values: [1] },
       'bardTwo filter serializes correctly with datasource'
+    );
+
+    // Test serializing a filter with no parameters
+    set(dashboard.filters.objectAt(0), 'parameters', {});
+    const serialized2 = dashboard.serialize();
+    assert.deepEqual(
+      serialized2.data.attributes.filters[0],
+      { dimension: 'bardOne.age', operator: 'in', field: undefined, values: [1, 2, 3] },
+      'bardOne filter serializes correctly with datasource'
     );
   });
 });


### PR DESCRIPTION
## Description
Dashboard filters are still using the old v1 format on the WS so it assumed all filters were for fili datasources (i.e. dimension filters that have a `field` parameter)

## Proposed Changes
- Use `canonicalName` rather than hardcoded string for better support

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
