### PR TITLE
Update: Line chart for missing data points

### DIFF
--- a/packages/core/addon/components/navi-visualizations/line-chart.ts
+++ b/packages/core/addon/components/navi-visualizations/line-chart.ts
@@ -160,13 +160,7 @@ export default class LineChart extends ChartBuildersBase<Args> {
   @computed('response.rows.length')
   get pointConfig() {
     const pointCount = this.response.rows.length;
-
-    //set point radius higher for single data
-    if (pointCount === 1) {
-      return { r: 2 };
-    }
-
-    return { r: 0 };
+    return pointCount === 1 ? { r: 3 } : { r: 2 };
   }
 
   /**

--- a/packages/core/app/styles/navi-core/visualizations/line-chart.less
+++ b/packages/core/app/styles/navi-core/visualizations/line-chart.less
@@ -37,7 +37,7 @@
   }
 
   .c3-line {
-    stroke-width: 2px;
+    stroke-width: 3px;
   }
 
   // Series coloring

--- a/packages/core/tests/unit/components/navi-visualizations/line-chart-test.ts
+++ b/packages/core/tests/unit/components/navi-visualizations/line-chart-test.ts
@@ -246,7 +246,7 @@ module('Unit | Component | line chart', function(hooks) {
         y: { show: true }
       },
       point: {
-        r: 0,
+        r: 2,
         focus: {
           expand: {
             r: 4
@@ -369,7 +369,7 @@ module('Unit | Component | line chart', function(hooks) {
     assert.deepEqual(
       component.config.point,
       {
-        r: 2,
+        r: 3,
         focus: {
           expand: { r: 4 }
         }
@@ -409,12 +409,12 @@ module('Unit | Component | line chart', function(hooks) {
     assert.deepEqual(
       component.config.point,
       {
-        r: 0,
+        r: 2,
         focus: {
           expand: { r: 4 }
         }
       },
-      'the point radius is 0 for a multiple data points'
+      'the point radius is 2 for a multiple data points'
     );
   });
 


### PR DESCRIPTION

## Description

Update Line chart for missing data points

## Proposed Changes

This PR increases the line chart radius and stroke-width to handle the case when there are missing data points

## Screenshots

<img width="1391" alt="Screen Shot 2021-01-27 at 9 42 12 PM" src="https://user-images.githubusercontent.com/2983409/106086864-8d0c3a00-60e8-11eb-8931-7ad20182f9fb.png">
<img width="1378" alt="Screen Shot 2021-01-27 at 9 37 31 PM" src="https://user-images.githubusercontent.com/2983409/106086876-92698480-60e8-11eb-96bf-ef80f8868068.png">


## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
