### PR TITLE
Update: Report and Dashboards use Denali buttons

### DIFF
--- a/packages/dashboards/addon/templates/components/navi-dashboard.hbs
+++ b/packages/dashboards/addon/templates/components/navi-dashboard.hbs
@@ -161,8 +161,20 @@
 {{#if this.dashboardIsDirty}}
   <div class="navi-dashboard__save-dialogue">
     {{#if @dashboard.canUserEdit}}
-      <button type="button" class="btn btn-secondary navi-dashboard__save-button" {{on "click" (queue (route-action "saveDashboard") @onModelSaveOrRevert)}}>Save Changes</button>
+      <DenaliButton 
+        class="navi-dashboard__save-button" 
+        @style="outline" 
+        {{on "click" (queue (route-action "saveDashboard") @onModelSaveOrRevert)}}
+      >
+        Save Changes
+      </DenaliButton>
     {{/if}}
-    <button type="button" class="btn btn-secondary navi-dashboard__revert-button" {{on "click" (queue (route-action "revertDashboard") @onModelSaveOrRevert)}}>Revert Changes</button>
+    <DenaliButton 
+      class="navi-dashboard__revert-button" 
+      @style="outline" 
+      {{on "click" (queue (route-action "revertDashboard") @onModelSaveOrRevert)}}
+    >
+      Revert Changes
+    </DenaliButton>
   </div>
 {{/if}}

--- a/packages/dashboards/addon/templates/dashboards/dashboard/widgets/widget.hbs
+++ b/packages/dashboards/addon/templates/dashboards/dashboard/widgets/widget.hbs
@@ -147,51 +147,49 @@
 
   <footer class="navi-report-widget__footer">
     {{#if this.isRunningReport}}
-      <button
-        type="button"
-        class="btn btn-primary navi-report-widget__cancel-btn"
-        onclick={{route-action "cancelReport" @model}}
+      <DenaliButton
+        class="navi-report-widget__cancel-btn"
+        {{on "click" (route-action "cancelReport" @model)}}
       >
         Cancel
-      </button>
+      </DenaliButton>
     {{else}}
-      <button
-        type="button"
-        class="btn btn-primary navi-report-widget__run-btn"
-        onclick={{pipe
+      <DenaliButton
+        class="navi-report-widget__run-btn"
+        {{on "click" (pipe
           (route-action "validate" @model)
           (route-action "runReport" @model)
-        }}
+        )}}
       >
         Run
-      </button>
+      </DenaliButton>
 
       {{#if (and @model.dashboard.canUserEdit @model.hasDirtyAttributes)}}
-        <button
-          type="button"
-          class="btn btn-secondary navi-report-widget__save-btn"
-          onclick={{pipe
+        <DenaliButton
+          class="navi-report-widget__save-btn"
+          @style="outline"
+          {{on "click" (pipe
             (route-action "validate" @model)
             (route-action "runReport" @model)
             (route-action "saveWidget" @model)
-          }}
+          )}}
         >
           {{#if @model.isNew}}
             Save Widget
           {{else}}
             Save Changes
           {{/if}}
-        </button>
+        </DenaliButton>
       {{/if}}
 
       {{#if (and @model.hasDirtyAttributes (not @model.isNew))}}
-        <button
-          type="button"
-          class="btn btn-secondary navi-report-widget__revert-btn"
-          onclick={{route-action "revertChanges" @model}}
+        <DenaliButton
+          @style="outline"
+          class="navi-report-widget__revert-btn"
+          {{on "click" (route-action "revertChanges" @model)}}
         >
           Revert Changes
-        </button>
+        </DenaliButton>
       {{/if}}
     {{/if}}
   </footer>

--- a/packages/dashboards/tests/acceptance/explore-widget-test.js
+++ b/packages/dashboards/tests/acceptance/explore-widget-test.js
@@ -328,7 +328,7 @@ module('Acceptance | Exploring Widgets', function(hooks) {
     assert.equal(currentRouteName(), 'dashboards.dashboard.widgets.widget.loading', 'Widget is loading');
 
     assert.deepEqual(
-      findAll('.navi-report-widget__footer .btn').map(e => e.textContent.trim()),
+      findAll('.navi-report-widget__footer button').map(e => e.textContent.trim()),
       ['Cancel'],
       'When widget is loading, the only footer button is `Cancel`'
     );
@@ -342,7 +342,7 @@ module('Acceptance | Exploring Widgets', function(hooks) {
     );
 
     assert.deepEqual(
-      findAll('.navi-report-widget__footer .btn').map(e => e.textContent.trim()),
+      findAll('.navi-report-widget__footer button').map(e => e.textContent.trim()),
       ['Run', 'Save Changes', 'Revert Changes'],
       'When not loading a widget, the standard footer buttons are available'
     );
@@ -357,7 +357,7 @@ module('Acceptance | Exploring Widgets', function(hooks) {
     );
 
     assert.deepEqual(
-      findAll('.navi-report-widget__footer .btn').map(e => e.textContent.trim()),
+      findAll('.navi-report-widget__footer button').map(e => e.textContent.trim()),
       ['Run', 'Save Changes', 'Revert Changes'],
       'When not loading a widget, the standard footer buttons are available'
     );

--- a/packages/reports/addon/components/report-view-overlay.hbs
+++ b/packages/reports/addon/components/report-view-overlay.hbs
@@ -10,12 +10,21 @@
     )}}
   {{else if this.shouldDisplay}}
     <div class="report-view-overlay__content">
-      <NaviButton title="Run query to update results" class="report-view-overlay__button report-view-overlay__button--run" @onClick={{@runReport}}>
+      <DenaliButton 
+        title="Run query to update results"
+        class="report-view-overlay__button report-view-overlay__button--run"
+        {{on "click" @runReport}}
+      >
         Run
-      </NaviButton>
-      <NaviButton title="Continue with old results" class="report-view-overlay__button report-view-overlay__button--dismiss" @type="secondary" @onClick={{this.dismiss}}>
+      </DenaliButton>
+      <DenaliButton
+        title="Continue with old results"
+        class="report-view-overlay__button report-view-overlay__button--dismiss"
+        @style="outline"
+        {{on "click" this.dismiss}}
+      >
         Dismiss
-      </NaviButton>
+      </DenaliButton>
     </div>
   {{/if}}
 </div>

--- a/packages/reports/addon/templates/reports/report.hbs
+++ b/packages/reports/addon/templates/reports/report.hbs
@@ -83,66 +83,51 @@
   <footer class="navi-report__footer">
     {{#unless this.isRunningReport}}
 
-      <NaviButton
+      <DenaliButton
         class="navi-report__run-btn"
-        @onClick={{pipe
-          (route-action "validate" this.model)
-          (route-action "forceRun" this.model)
-        }}
+        {{on "click" (pipe (route-action "validate" this.model) (route-action "forceRun" this.model))}}
       >
         Run
-      </NaviButton>
+      </DenaliButton>
 
       {{#if (and this.model.isOwner this.model.hasDirtyAttributes)}}
-        <NaviButton
+        <DenaliButton
           class="navi-report__save-btn"
-          @type="secondary"
-          @onClick={{pipe
-            (route-action "validate" this.model)
-            (route-action "runReport" this.model)
-            (route-action "saveReport" this.model)
-          }}
+          @style="outline"
+          {{on "click" (pipe (route-action "validate" this.model) (route-action "runReport" this.model) (route-action "saveReport" this.model))}}
         >
           {{#if this.model.isNew}}
             Save Report
           {{else}}
             Save
           {{/if}}
-        </NaviButton>
+        </DenaliButton>
 
         {{#unless this.model.isNew}}
-          <NaviButton
+          <DenaliButton
             class="navi-report__save-as-btn"
-            @type="secondary"
-            @onClick={{pipe
-              (route-action "validate" this.model)
-              (route-action "runReport" this.model)
-              (toggle "showSaveAs" this)
-          }}>
+            @style="outline"
+            {{on "click" (pipe (route-action "validate" this.model) (route-action "runReport" this.model) (toggle "showSaveAs" this))}}
+          >
             Save As ...
-          </NaviButton>
+          </DenaliButton>
         {{/unless}}
       {{/if}}
 
       {{#if (and this.model.hasDirtyAttributes (not this.model.isNew))}}
-        <NaviButton
+        <DenaliButton
           class="navi-report__revert-btn"
-          @type="secondary"
-          @onClick={{route-action "revertChanges" this.model}}
+          @style="outline"
+          {{on "click" (route-action "revertChanges" this.model)}}
         >
           Revert
-        </NaviButton>
+        </DenaliButton>
       {{/if}}
 
     {{else}}
-
-      <NaviButton
-        class="navi-report__cancel-btn"
-        @onClick={{route-action "cancelReport" this.model}}
-      >
+      <DenaliButton class="navi-report__cancel-btn" {{on "click" (route-action "cancelReport" this.model)}}>
         Cancel
-      </NaviButton>
-
+      </DenaliButton>
     {{/unless}}
   </footer>
 </div>

--- a/packages/reports/tests/acceptance/report-test.js
+++ b/packages/reports/tests/acceptance/report-test.js
@@ -2066,7 +2066,7 @@ module('Acceptance | Navi Report', function(hooks) {
 
     await waitFor('.navi-report__cancel-btn', { timeout: 5000 });
 
-    let buttons = findAll('.navi-report__footer .navi-button');
+    let buttons = findAll('.navi-report__footer .button');
     assert.dom('.navi-loader__spinner').isVisible('Report is loading');
 
     assert.deepEqual(
@@ -2094,7 +2094,7 @@ module('Acceptance | Navi Report', function(hooks) {
     assert.equal(currentURL(), '/reports/13/edit', 'Clicking `Cancel` brings the user to the edit route');
 
     assert.deepEqual(
-      findAll('.navi-report__footer .navi-button').map(e => e.textContent.trim()),
+      findAll('.navi-report__footer .button').map(e => e.textContent.trim()),
       ['Run'],
       'When not loading a report, the standard footer buttons are available'
     );
@@ -2104,7 +2104,7 @@ module('Acceptance | Navi Report', function(hooks) {
     assert.equal(currentURL(), '/reports/13/view', 'Running the report brings the user to the view route');
 
     assert.deepEqual(
-      findAll('.navi-report__footer .navi-button').map(e => e.textContent.trim()),
+      findAll('.navi-report__footer .button').map(e => e.textContent.trim()),
       ['Run'],
       'When not loading a report, the standard footer buttons are available'
     );


### PR DESCRIPTION
## Description
Move report and dashboard buttons over to denali

## Screenshots

![report buttons](https://user-images.githubusercontent.com/12093492/106163599-f888f280-614e-11eb-9232-fe35f6096e54.png)
![dashboard buttons](https://user-images.githubusercontent.com/12093492/106163604-fa52b600-614e-11eb-9a31-fcbaf4f01d8c.png)


## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
