### PR TITLE
Update: Add back wrapper class

### DIFF
--- a/packages/directory/addon/components/dir-search-bar.hbs
+++ b/packages/directory/addon/components/dir-search-bar.hbs
@@ -2,6 +2,7 @@
 <DenaliInput
   @iconBack="search"
   @iconBackClass="is-brand-300"
+  @wrapperClass="dir-search-bar"
   value={{@query}}
   type="text"
   placeholder="Search"


### PR DESCRIPTION
## Description
Accidentally delete a wrapper class so the style fixups for the search bar were not being used

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
