### PR TITLE
Update: Migrate less to sass for app

### DIFF
--- a/packages/app/app/styles/app.less
+++ b/packages/app/app/styles/app.less
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Yahoo Holdings Inc.
+ * Copyright 2021, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 
@@ -9,6 +9,3 @@
 @import 'navi-dashboards';
 @import 'navi-reports';
 @import 'navi-directory';
-
-//app styles
-@import 'views/index';

--- a/packages/app/app/styles/app.scss
+++ b/packages/app/app/styles/app.scss
@@ -1,11 +1,14 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2021, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 
 @import 'denali/denali';
 @import 'denali/ember-power-select';
-@import 'theme.scss';
 @import 'navi-directory';
 @import 'navi-reports';
+
+// app styles
+@import 'theme.scss';
 @import 'components/index.scss';
+@import 'views/index.scss';

--- a/packages/app/app/styles/views/dashboards.scss
+++ b/packages/app/app/styles/views/dashboards.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2021, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 .navi-dashboard-container {

--- a/packages/app/app/styles/views/index.scss
+++ b/packages/app/app/styles/views/index.scss
@@ -1,7 +1,7 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2021, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 
-@import 'dashboards';
-@import 'reports';
+@import 'dashboards.scss';
+@import 'reports.scss';

--- a/packages/app/app/styles/views/reports.scss
+++ b/packages/app/app/styles/views/reports.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, Yahoo Holdings Inc.
+ * Copyright 2021, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 .navi-report {


### PR DESCRIPTION
## Description
Move `.less` to `.scss` for app styles

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
