### PR TITLE
Update: App index.html don't zoom on input focus

### DIFF
--- a/packages/app/app/index.html
+++ b/packages/app/app/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>Yavin</title>
     <meta name="description" content="" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 
     {{content-for "head"}}
 


### PR DESCRIPTION
## Description
Clicking the search button input slightly zooms in the page and makes the user zoom out after clicking

## Proposed Changes
- Update meta tag so that the zoom does not change when focusing inputs, but still allows users to manually zoom (https://stackoverflow.com/a/46254706)

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
