### PR TITLE
Build: dev n prod build (fixes #CARBON-552)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/yahoo/yavin"
   },
   "scripts": {
-    "build": "lerna run build-ui --scope navi-app --stream",
+    "build-ui": "lerna run build --scope navi-app --stream",
     "start": "cd packages/webservice && ./gradlew bootRun",
     "postinstall": "lerna bootstrap --concurrency 2 --ci",
     "test": "lerna run test --stream",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/yahoo/yavin"
   },
   "scripts": {
-    "build": "lerna run build-$npm_config_build_env --scope navi-app --stream",
+    "build": "lerna run build-ui --scope navi-app --stream",
     "start": "cd packages/webservice && ./gradlew bootRun",
     "postinstall": "lerna bootstrap --concurrency 2 --ci",
     "test": "lerna run test --stream",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/yahoo/yavin"
   },
   "scripts": {
-    "build-ui": "lerna run build --scope navi-app --stream",
+    "build": "lerna run build-$npm_config_build_env --scope navi-app --stream",
     "start": "cd packages/webservice && ./gradlew bootRun",
     "postinstall": "lerna bootstrap --concurrency 2 --ci",
     "test": "lerna run test --stream",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,7 +13,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "build-ui": "cmd=\"ember build --environment=$npm_config_environment\" && echo $cmd && eval $cmd ",
+    "build": "cmd=\"ember build --environment=$npm_config_environment\" && echo $cmd && eval $cmd ",
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",
     "lint": "npm run lint:hbs && npm run lint:js",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,8 +13,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "build-dev": "ember build --environment=development",
-    "build-prod": "ember build --environment=production",
+    "build-ui": "cmd=\"ember build --environment=$npm_config_environment\" && echo $cmd && eval $cmd ",
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",
     "lint": "npm run lint:hbs && npm run lint:js",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,8 +13,8 @@
   },
   "main": "index.js",
   "scripts": {
-    "build": "ember build",
-    "prodbuild": "ember build --environment=production",
+    "build-dev": "ember build --environment=development",
+    "build-prod": "ember build --environment=production",
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",
     "lint": "npm run lint:hbs && npm run lint:js",

--- a/packages/webservice/README.md
+++ b/packages/webservice/README.md
@@ -96,6 +96,12 @@ dependencies {
 To run the demo app
 
 ```shell script
+$ ./gradlew bootRun -Pbuild_env=prod
+```
+
+Build for dev environment
+
+```shell script
 $ ./gradlew bootRun
 ```
 

--- a/packages/webservice/README.md
+++ b/packages/webservice/README.md
@@ -96,7 +96,7 @@ dependencies {
 To run the demo app
 
 ```shell script
-$ ./gradlew bootRun -Pbuild_env=prod
+$ ./gradlew bootRun -Penvironment=production
 ```
 
 Build for dev environment

--- a/packages/webservice/app/build.gradle.kts
+++ b/packages/webservice/app/build.gradle.kts
@@ -3,13 +3,13 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 description = "app"
 
-val build_env: String by project
+val environment: String by project
 var build_env_final : String
 
-if (!project.hasProperty("build_env")){
-  build_env_final = "dev"
+if (!project.hasProperty("environment")){
+  build_env_final = "development"
 }else{
-  build_env_final = build_env
+  build_env_final = environment
 }
 
 plugins {
@@ -74,7 +74,7 @@ tasks.register<NpmTask>("installUIDependencies") {
 tasks.register<NpmTask>("buildUI") {
   dependsOn("installUIDependencies")
   setEnvironment(mapOf("DISABLE_MOCKS" to true))
-  setArgs(listOf("run-script", "build","--build_env=${build_env_final}"))
+  setArgs(listOf("run-script", "build","--environment=${build_env_final}"))
 }
 
 tasks.register<Copy>("copyNaviApp") {

--- a/packages/webservice/app/build.gradle.kts
+++ b/packages/webservice/app/build.gradle.kts
@@ -4,13 +4,10 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 description = "app"
 
 val environment: String by project
-var build_env_final : String
 
-if (!project.hasProperty("environment")){
-  build_env_final = "development"
-}else{
-  build_env_final = environment
-}
+val buildEnv = if (!project.hasProperty("environment")) "development" else environment
+
+
 
 plugins {
     id("org.springframework.boot") version "2.3.1.RELEASE"
@@ -74,7 +71,7 @@ tasks.register<NpmTask>("installUIDependencies") {
 tasks.register<NpmTask>("buildUI") {
   dependsOn("installUIDependencies")
   setEnvironment(mapOf("DISABLE_MOCKS" to true))
-  setArgs(listOf("run-script", "build","--environment=${build_env_final}"))
+  setArgs(listOf("run-script", "build-ui","--environment=${buildEnv}"))
 }
 
 tasks.register<Copy>("copyNaviApp") {

--- a/packages/webservice/app/build.gradle.kts
+++ b/packages/webservice/app/build.gradle.kts
@@ -3,6 +3,15 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 description = "app"
 
+val build_env: String by project
+var build_env_final : String
+
+if (!project.hasProperty("build_env")){
+  build_env_final = "dev"
+}else{
+  build_env_final = build_env
+}
+
 plugins {
     id("org.springframework.boot") version "2.3.1.RELEASE"
     id("io.spring.dependency-management") version "1.0.9.RELEASE"
@@ -65,7 +74,7 @@ tasks.register<NpmTask>("installUIDependencies") {
 tasks.register<NpmTask>("buildUI") {
   dependsOn("installUIDependencies")
   setEnvironment(mapOf("DISABLE_MOCKS" to true))
-  setArgs(listOf("run-script", "build-ui"))
+  setArgs(listOf("run-script", "build","--build_env=${build_env_final}"))
 }
 
 tasks.register<Copy>("copyNaviApp") {


### PR DESCRIPTION
Resolves #

<!-- The above line will close the issue upon merge -->

## Description
Separate prod and dev env builds

## Proposed Changes
pass gradle variable while running build to indicate env.

example : `./gradlew bootJar -Pbuild_env=prod`

If no arg provided then default is dev. Values are dev | prod
-

## Screenshots

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
