### PR TITLE
Update: Convert intervals to [inclusive, inclusive]

### DIFF
--- a/packages/core/addon/components/navi-cell-renderers/time-dimension.ts
+++ b/packages/core/addon/components/navi-cell-renderers/time-dimension.ts
@@ -14,7 +14,7 @@ import BaseCellRenderer from './base';
 import { computed } from '@ember/object';
 //@ts-ignore
 import { formatDateForGranularity } from 'navi-core/helpers/format-date-for-granularity';
-import { Grain } from 'navi-data/addon/utils/date';
+import { Grain } from 'navi-data/utils/date';
 
 export default class TimeDimensionCellRenderer extends BaseCellRenderer {
   /**

--- a/packages/core/addon/mirage/fixtures/reports.js
+++ b/packages/core/addon/mirage/fixtures/reports.js
@@ -576,12 +576,12 @@ export default [
           {
             field: 'displayCurrency',
             type: 'dimension',
-            displayName: 'Display Currency'
+            displayName: 'Display Currency',
           },
           {
             field: { metric: 'usedAmount', parameters: {} },
             type: 'metric',
-            displayName: 'Used Amount'
+            displayName: 'Used Amount',
           },
           {
             field: { metric: 'revenue', parameters: { currency: 'GIL' } },

--- a/packages/core/addon/mirage/fixtures/reports.js
+++ b/packages/core/addon/mirage/fixtures/reports.js
@@ -574,9 +574,19 @@ export default [
             displayName: 'Container',
           },
           {
+            field: 'displayCurrency',
+            type: 'dimension',
+            displayName: 'Display Currency'
+          },
+          {
             field: { metric: 'usedAmount', parameters: {} },
             type: 'metric',
-            displayName: 'Used Amount',
+            displayName: 'Used Amount'
+          },
+          {
+            field: { metric: 'revenue', parameters: { currency: 'GIL' } },
+            type: 'metric',
+            displayName: 'Revenue (GIL)',
           },
         ],
       },

--- a/packages/core/addon/utils/chart-axis-date-time-formats.ts
+++ b/packages/core/addon/utils/chart-axis-date-time-formats.ts
@@ -3,7 +3,7 @@
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 
-import { Grain } from 'navi-data/addon/utils/date';
+import { Grain } from 'navi-data/utils/date';
 
 const grainFormats: Record<Grain, string> = {
   second: 'HH:mm:ss',

--- a/packages/core/tests/unit/models/report-test.js
+++ b/packages/core/tests/unit/models/report-test.js
@@ -15,7 +15,7 @@ const ExpectedRequest = {
     filters: [
       {
         operator: 'bet',
-        values: ['2015-11-09 00:00:00.000', '2015-11-16 00:00:00.000'],
+        values: ['2015-11-09T00:00:00.000Z', '2015-11-15T00:00:00.000Z'],
         field: 'network.dateTime',
         parameters: {
           grain: 'day',

--- a/packages/core/tests/unit/utils/request-test.ts
+++ b/packages/core/tests/unit/utils/request-test.ts
@@ -409,7 +409,7 @@ module('Unit | Utils | Request', function (hooks) {
     );
   });
 
-  test('normalize v1 to v2 - inclusive end date', function(assert) {
+  test('normalize v1 to v2 - inclusive end date', function (assert) {
     assert.expect(5);
 
     request.logicalTable.timeGrain = 'day';
@@ -423,8 +423,8 @@ module('Unit | Utils | Request', function (hooks) {
         operator: 'bet',
         values: ['2021-01-01T00:00:00.000Z', '2021-01-02T00:00:00.000Z'],
         parameters: {
-          grain: 'day'
-        }
+          grain: 'day',
+        },
       },
       'day timegrain filters are moved to inclusive end date'
     );
@@ -440,8 +440,8 @@ module('Unit | Utils | Request', function (hooks) {
         operator: 'bet',
         values: ['2021-02-01T00:00:00.000Z', '2021-02-01T00:00:00.000Z'],
         parameters: {
-          grain: 'isoWeek'
-        }
+          grain: 'isoWeek',
+        },
       },
       'week (isoWeek) timegrain filters are moved to inclusive end date'
     );
@@ -457,8 +457,8 @@ module('Unit | Utils | Request', function (hooks) {
         operator: 'bet',
         values: ['2021-01-01T00:00:00.000Z', '2021-02-01T00:00:00.000Z'],
         parameters: {
-          grain: 'month'
-        }
+          grain: 'month',
+        },
       },
       'month timegrain filters are moved to inclusive end date'
     );
@@ -474,8 +474,8 @@ module('Unit | Utils | Request', function (hooks) {
         operator: 'bet',
         values: ['2021-01-01T00:00:00.000Z', '2021-01-01T00:00:00.000Z'],
         parameters: {
-          grain: 'quarter'
-        }
+          grain: 'quarter',
+        },
       },
       'quarter timegrain filters are moved to inclusive end date'
     );
@@ -491,8 +491,8 @@ module('Unit | Utils | Request', function (hooks) {
         operator: 'bet',
         values: ['2021-01-01T00:00:00.000Z', '2021-01-01T00:00:00.000Z'],
         parameters: {
-          grain: 'year'
-        }
+          grain: 'year',
+        },
       },
       'year timegrain filters are moved to inclusive end date'
     );

--- a/packages/data/addon/adapters/facts/bard.ts
+++ b/packages/data/addon/adapters/facts/bard.ts
@@ -158,8 +158,9 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
       end = endMoment.add(1, getPeriodForGrain(filterGrain)).toISOString();
     }
 
-    start = start.replace('T00:00:00.000Z', '');
-    end = end.replace('T00:00:00.000Z', '');
+    // Removing Z to strip off time zone if it's there
+    start = start.replace('Z', '');
+    end = end.replace('Z', '');
     return `${start}/${end}`;
   }
 

--- a/packages/data/addon/adapters/facts/elide.ts
+++ b/packages/data/addon/adapters/facts/elide.ts
@@ -22,7 +22,7 @@ import GQLQueries from 'navi-data/gql/fact-queries';
 import { task, timeout } from 'ember-concurrency';
 import { v1 } from 'ember-uuid';
 import moment, { Moment } from 'moment';
-import { getPeriodForGrain, Grain } from 'navi-data/utils/date';
+import { Grain } from 'navi-data/utils/date';
 
 const escape = (value: string) => value.replace(/'/g, "\\\\'");
 
@@ -94,16 +94,9 @@ export default class ElideFactsAdapter extends EmberObject implements NaviFactAd
         const grain = filter.parameters.grain as Grain;
         let timeValues: (Moment | string)[] = filterVals;
         if (['bet', 'nbet'].includes(operator)) {
+          let startValue = String(filterVals[0]);
           let endValue = String(filterVals[1]);
-          const endMoment = moment.utc(String(filterVals[1]));
-          if (endMoment.isValid()) {
-            // convert inclusive filter values to exclusive for Interval
-            endValue = endMoment.add(1, getPeriodForGrain(grain)).toISOString();
-          }
-          const { start, end } = Interval.parseFromStrings(String(filterVals[0]), endValue).asMomentsForTimePeriod(
-            grain
-          );
-          end.subtract(1, getPeriodForGrain(grain));
+          const { start, end } = Interval.parseInclusive(startValue, endValue, grain).asMomentsInclusive(grain);
           timeValues = [start, end];
         }
         filterVals = timeValues.map((v) => this.formatTimeValue(v, grain));

--- a/packages/data/addon/adapters/facts/elide.ts
+++ b/packages/data/addon/adapters/facts/elide.ts
@@ -22,7 +22,7 @@ import GQLQueries from 'navi-data/gql/fact-queries';
 import { task, timeout } from 'ember-concurrency';
 import { v1 } from 'ember-uuid';
 import moment, { Moment } from 'moment';
-import { getPeriodForGrain, Grain } from 'navi-data/utils/date';
+import { Grain } from 'navi-data/utils/date';
 
 const escape = (value: string) => value.replace(/'/g, "\\\\'");
 
@@ -98,11 +98,6 @@ export default class ElideFactsAdapter extends EmberObject implements NaviFactAd
             String(filterVals[0]),
             String(filterVals[1])
           ).asMomentsForTimePeriod(grain);
-          if (moment.utc(filterVals[1]).isValid()) {
-            // only change end if it's a date (exlcude macros)
-            // TODO: Time dimension date filter values for bet are stored as [inclusive, exclusive), temporary fix for elide
-            end.subtract(1, getPeriodForGrain(grain));
-          }
           timeValues = [start, end];
         }
         filterVals = timeValues.map((v) => this.formatTimeValue(v, grain));

--- a/packages/data/addon/mirage/routes/bard-lite.ts
+++ b/packages/data/addon/mirage/routes/bard-lite.ts
@@ -185,6 +185,15 @@ export default function (
 
     // Get date range from query params + grain
     const [start, end] = request.queryParams.dateTime.split('/');
+    if (start === end) {
+      return new Response(
+        400,
+        {},
+        {
+          description: `Date time cannot have zero length intervals. ${start}/${end}.`
+        }
+      );
+    }
     let dates = _getDates(grain, start, end);
     let filters: FiliFilter[] = [];
     if (request.queryParams.filters) {

--- a/packages/data/addon/mirage/routes/bard-lite.ts
+++ b/packages/data/addon/mirage/routes/bard-lite.ts
@@ -190,7 +190,7 @@ export default function (
         400,
         {},
         {
-          description: `Date time cannot have zero length intervals. ${start}/${end}.`
+          description: `Date time cannot have zero length intervals. ${start}/${end}.`,
         }
       );
     }

--- a/packages/data/addon/utils/classes/interval.ts
+++ b/packages/data/addon/utils/classes/interval.ts
@@ -152,6 +152,21 @@ export default class Interval {
   }
 
   /**
+   * Converts interval into a POJO with moments that are aligned and inclusive to the given time grain
+   * @param grain - grain to align to
+   * @returns object with start and end properties
+   */
+  asMomentsInclusive(grain: Grain): SerializedWithEnd<Moment> {
+    let { start, end } = this.asMomentsForTimePeriod(grain);
+    end.subtract(1, getPeriodForGrain(grain));
+
+    return {
+      start,
+      end,
+    };
+  }
+
+  /**
    * Converts interval from [inclusive, inclusive] to [inclusive, exclusive] for the given grain
    * @param grain - grain to align to
    * @returns new interval with inclusive exclusive
@@ -242,7 +257,7 @@ export default class Interval {
   /**
    * @param start - interval start
    * @param end - interval end
-   * @returns object parsed from given strings
+   * @returns inclusive/exclusive interval
    */
   static parseFromStrings(start: string, end: string): Interval {
     const intervalEnd = Interval.fromString(end);
@@ -250,6 +265,24 @@ export default class Interval {
     assert('Interval start must not be "next"', intervalStart !== 'next');
     assert('Interval end must be: moment string or macro', !Duration.isDuration(intervalEnd));
 
+    return new Interval(intervalStart, intervalEnd);
+  }
+
+  /**
+   * @param start - interval start
+   * @param end - interval end
+   * @param grain - The grain to be included
+   * @returns inclusive/exclusive interval that includes the end date at the given grain
+   */
+  static parseInclusive(start: string, end: string, grain: Grain): Interval {
+    const intervalStart = Interval.fromString(start);
+    const intervalEnd = Interval.fromString(end);
+    if (moment.isMoment(intervalEnd)) {
+      intervalEnd.add(1, getPeriodForGrain(grain));
+    }
+
+    assert('Interval start must not be "next"', intervalStart !== 'next');
+    assert('Interval end must be: moment string or macro', !Duration.isDuration(intervalEnd));
     return new Interval(intervalStart, intervalEnd);
   }
 

--- a/packages/data/addon/utils/classes/interval.ts
+++ b/packages/data/addon/utils/classes/interval.ts
@@ -127,43 +127,23 @@ export default class Interval {
    * @param makeEndInclusiveIfSame - add an extra time period to include end date if it's equal to start date
    * @returns object with start and end properties
    */
-  asMomentsForTimePeriod(grain: Grain): SerializedWithEnd<Moment> {
-    let start = this._start;
-    let end: IntervalEnd | undefined = this._end;
+  asMomentsForTimePeriod(grain: Grain, makeEndInclusiveIfSame = true): SerializedWithEnd<Moment> {
+    const period = getPeriodForGrain(grain);
 
-    // Copy moments
-    if (moment.isMoment(start)) {
-      start = start.clone();
-    }
-    if (moment.isMoment(end)) {
-      end = end.clone();
-    }
+    let { start, end } = this.asMoments();
 
-    /*
-     * Macro substitution
-     * Note: currently only supports "current" and "next" macros
-     */
-    if (start === CURRENT) {
-      start = moment.utc();
-    }
-    if (end === CURRENT) {
-      end = moment.utc().subtract(1, getPeriodForGrain(grain));
-    }
-    if (end === NEXT) {
-      end = moment.utc();
-    }
-
-    // Duration substitution
-    if (Duration.isDuration(start)) {
-      const durationGrain = start.getUnit();
-      assert('The duration has a unit', durationGrain);
-      let localEnd = end.clone().add(1, getPeriodForGrain(durationGrain));
-      start = DurationUtils.subtractDurationFromDate(localEnd, start);
+    // Handle the case where the end is undefined, hence it is 'next'
+    if (end === undefined) {
+      end = moment.utc().add(1, period);
     }
 
     // Make sure moments are start of time period
     start.startOf(grain);
     end.startOf(grain);
+
+    if (makeEndInclusiveIfSame && start.isSame(end)) {
+      end.startOf(grain).add(1, period);
+    }
 
     return {
       start,
@@ -216,7 +196,7 @@ export default class Interval {
   diffForTimePeriod(grain: Grain): number {
     const moments = this.asMomentsForTimePeriod(grain);
     const period = getPeriodForGrain(grain);
-    return moments.end.diff(moments.start, period) + 1;
+    return moments.end.diff(moments.start, period);
   }
 
   /**

--- a/packages/data/tests/unit/adapters/facts/bard-test.ts
+++ b/packages/data/tests/unit/adapters/facts/bard-test.ts
@@ -753,7 +753,7 @@ module('Unit | Adapter | facts/bard', function (hooks) {
     assert.deepEqual(
       Adapter._buildQuery(TestRequest),
       {
-        dateTime: '2015-01-03/2015-01-04',
+        dateTime: '2015-01-03/2015-01-04T00:00:00.000',
         filters: 'd3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notin[""]',
         metrics: 'm1,m2,r(p=123)',
         having: 'm1-gt[0]',
@@ -777,7 +777,7 @@ module('Unit | Adapter | facts/bard', function (hooks) {
     assert.deepEqual(
       Adapter._buildQuery(noFiltersAndNoHavings),
       {
-        dateTime: '2015-01-03/2015-01-04',
+        dateTime: '2015-01-03/2015-01-04T00:00:00.000',
         metrics: 'm1,m2,r(p=123)',
         format: 'json',
       },
@@ -787,7 +787,7 @@ module('Unit | Adapter | facts/bard', function (hooks) {
     assert.deepEqual(
       Adapter._buildQuery(TestRequest, { format: 'jsonApi' }),
       {
-        dateTime: '2015-01-03/2015-01-04',
+        dateTime: '2015-01-03/2015-01-04T00:00:00.000',
         filters: 'd3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notin[""]',
         metrics: 'm1,m2,r(p=123)',
         having: 'm1-gt[0]',
@@ -803,7 +803,7 @@ module('Unit | Adapter | facts/bard', function (hooks) {
     assert.deepEqual(
       Adapter._buildQuery(sortRequest),
       {
-        dateTime: '2015-01-03/2015-01-04',
+        dateTime: '2015-01-03/2015-01-04T00:00:00.000',
         filters: 'd3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notin[""]',
         format: 'json',
         metrics: 'm1,m2,r(p=123)',
@@ -816,7 +816,7 @@ module('Unit | Adapter | facts/bard', function (hooks) {
     assert.deepEqual(
       Adapter._buildQuery(TestRequest, { cache: false }),
       {
-        dateTime: '2015-01-03/2015-01-04',
+        dateTime: '2015-01-03/2015-01-04T00:00:00.000',
         filters: 'd3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notin[""]',
         metrics: 'm1,m2,r(p=123)',
         having: 'm1-gt[0]',
@@ -842,7 +842,7 @@ module('Unit | Adapter | facts/bard', function (hooks) {
     assert.deepEqual(
       Adapter._buildQuery(TestRequest, options),
       {
-        dateTime: '2015-01-03/2015-01-04',
+        dateTime: '2015-01-03/2015-01-04T00:00:00.000',
         filters: 'd3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notin[""]',
         metrics: 'm1,m2,r(p=123)',
         having: 'm1-gt[0]',
@@ -861,7 +861,7 @@ module('Unit | Adapter | facts/bard', function (hooks) {
     assert.deepEqual(
       Adapter._buildQuery(TestRequest),
       {
-        dateTime: '2015-01-03/2015-01-04',
+        dateTime: '2015-01-03/2015-01-04T00:00:00.000',
         filters: 'd3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notin[""]',
         metrics: 'm1,m2,r(p=123)',
         having: 'm1-gt[0]',
@@ -874,7 +874,7 @@ module('Unit | Adapter | facts/bard', function (hooks) {
     assert.deepEqual(
       Adapter._buildQuery(TestRequest, {}),
       {
-        dateTime: '2015-01-03/2015-01-04',
+        dateTime: '2015-01-03/2015-01-04T00:00:00.000',
         filters: 'd3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notin[""]',
         metrics: 'm1,m2,r(p=123)',
         having: 'm1-gt[0]',
@@ -887,7 +887,7 @@ module('Unit | Adapter | facts/bard', function (hooks) {
     assert.deepEqual(
       Adapter._buildQuery(TestRequest, { page: 1, perPage: 100 }),
       {
-        dateTime: '2015-01-03/2015-01-04',
+        dateTime: '2015-01-03/2015-01-04T00:00:00.000',
         filters: 'd3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notin[""]',
         metrics: 'm1,m2,r(p=123)',
         having: 'm1-gt[0]',
@@ -901,7 +901,7 @@ module('Unit | Adapter | facts/bard', function (hooks) {
     assert.deepEqual(
       Adapter._buildQuery(TestRequest, { format: 'csv' }),
       {
-        dateTime: '2015-01-03/2015-01-04',
+        dateTime: '2015-01-03/2015-01-04T00:00:00.000',
         filters: 'd3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notin[""]',
         metrics: 'm1,m2,r(p=123)',
         having: 'm1-gt[0]',
@@ -916,13 +916,13 @@ module('Unit | Adapter | facts/bard', function (hooks) {
 
     assert.equal(
       decodeURIComponent(Adapter.urlForFindQuery(TestRequest)),
-      `${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=desc/?dateTime=2015-01-03/2015-01-04&metrics=m1,m2,r(p=123)&filters=d3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notin[""]&having=m1-gt[0]&format=json`,
+      `${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=desc/?dateTime=2015-01-03/2015-01-04T00:00:00.000&metrics=m1,m2,r(p=123)&filters=d3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notin[""]&having=m1-gt[0]&format=json`,
       'urlForFindQuery correctly built the URL for the provided request'
     );
 
     assert.equal(
       decodeURIComponent(Adapter.urlForFindQuery(TestRequest, { format: 'csv' })),
-      `${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=desc/?dateTime=2015-01-03/2015-01-04&metrics=m1,m2,r(p=123)&filters=d3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notin[""]&having=m1-gt[0]&format=csv`,
+      `${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=desc/?dateTime=2015-01-03/2015-01-04T00:00:00.000&metrics=m1,m2,r(p=123)&filters=d3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notin[""]&having=m1-gt[0]&format=csv`,
       'urlForFindQuery correctly built the URL for the provided request with the format option'
     );
 
@@ -940,7 +940,7 @@ module('Unit | Adapter | facts/bard', function (hooks) {
     };
     assert.equal(
       decodeURIComponent(Adapter.urlForFindQuery(onlyDateFilter)),
-      `${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=desc/?dateTime=2015-01-03/2015-01-04&metrics=m1,m2,r(p=123)&format=json`,
+      `${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=desc/?dateTime=2015-01-03/2015-01-04T00:00:00.000&metrics=m1,m2,r(p=123)&format=json`,
       'urlForFindQuery correctly built the URL for a request with no filters'
     );
 
@@ -972,19 +972,19 @@ module('Unit | Adapter | facts/bard', function (hooks) {
     };
     assert.equal(
       decodeURIComponent(Adapter.urlForFindQuery(requestWithSort)),
-      `${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=desc/?dateTime=2015-01-03/2015-01-04&metrics=m1,m2,r(p=123)&sort=m1|desc,m2|desc&format=json`,
+      `${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=desc/?dateTime=2015-01-03/2015-01-04T00:00:00.000&metrics=m1,m2,r(p=123)&sort=m1|desc,m2|desc&format=json`,
       'urlForFindQuery correctly built the URL for a request with sort'
     );
 
     assert.equal(
       decodeURIComponent(Adapter.urlForFindQuery(TestRequest, { cache: false })),
-      `${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=desc/?dateTime=2015-01-03/2015-01-04&metrics=m1,m2,r(p=123)&filters=d3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notin[""]&having=m1-gt[0]&format=json&_cache=false`,
+      `${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=desc/?dateTime=2015-01-03/2015-01-04T00:00:00.000&metrics=m1,m2,r(p=123)&filters=d3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notin[""]&having=m1-gt[0]&format=json&_cache=false`,
       'urlForFindQuery correctly built the URL for the provided request with the cache option'
     );
 
     assert.equal(
       decodeURIComponent(Adapter.urlForFindQuery(TestRequest, { dataSourceName: 'bardTwo' })),
-      `${HOST2}/v1/data/table1/grain1/d1;show=id/d2;show=desc/?dateTime=2015-01-03/2015-01-04&metrics=m1,m2,r(p=123)&filters=d3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notin[""]&having=m1-gt[0]&format=json`,
+      `${HOST2}/v1/data/table1/grain1/d1;show=id/d2;show=desc/?dateTime=2015-01-03/2015-01-04T00:00:00.000&metrics=m1,m2,r(p=123)&filters=d3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notin[""]&having=m1-gt[0]&format=json`,
       'uriForFindQuery renders alternative host name if option is given'
     );
   });
@@ -993,13 +993,13 @@ module('Unit | Adapter | facts/bard', function (hooks) {
     assert.expect(6);
     assert.equal(
       decodeURIComponent(await Adapter.urlForDownloadQuery(TestRequest)),
-      `${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=desc/?dateTime=2015-01-03/2015-01-04&metrics=m1,m2,r(p=123)&filters=d3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notin[""]&having=m1-gt[0]&format=json`,
+      `${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=desc/?dateTime=2015-01-03/2015-01-04T00:00:00.000&metrics=m1,m2,r(p=123)&filters=d3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notin[""]&having=m1-gt[0]&format=json`,
       'urlForDownloadQuery correctly built the URL for the provided request'
     );
 
     assert.equal(
       decodeURIComponent(await Adapter.urlForDownloadQuery(TestRequest, { format: 'csv' })),
-      `${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=desc/?dateTime=2015-01-03/2015-01-04&metrics=m1,m2,r(p=123)&filters=d3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notin[""]&having=m1-gt[0]&format=csv`,
+      `${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=desc/?dateTime=2015-01-03/2015-01-04T00:00:00.000&metrics=m1,m2,r(p=123)&filters=d3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notin[""]&having=m1-gt[0]&format=csv`,
       'urlForDownloadQuery correctly built the URL for the provided request with the format option'
     );
 
@@ -1017,7 +1017,7 @@ module('Unit | Adapter | facts/bard', function (hooks) {
     };
     assert.equal(
       decodeURIComponent(await Adapter.urlForDownloadQuery(onlyDateFilter)),
-      `${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=desc/?dateTime=2015-01-03/2015-01-04&metrics=m1,m2,r(p=123)&format=json`,
+      `${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=desc/?dateTime=2015-01-03/2015-01-04T00:00:00.000&metrics=m1,m2,r(p=123)&format=json`,
       'urlForDownloadQuery correctly built the URL for a request with only date filter'
     );
 
@@ -1039,19 +1039,19 @@ module('Unit | Adapter | facts/bard', function (hooks) {
     };
     assert.equal(
       decodeURIComponent(await Adapter.urlForDownloadQuery(requestWithSort)),
-      `${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=desc/?dateTime=2015-01-03/2015-01-04&metrics=m1,m2,r(p=123)&sort=m1|desc,m2|desc&format=json`,
+      `${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=desc/?dateTime=2015-01-03/2015-01-04T00:00:00.000&metrics=m1,m2,r(p=123)&sort=m1|desc,m2|desc&format=json`,
       'urlForDownloadQuery correctly built the URL for a request with sort'
     );
 
     assert.equal(
       decodeURIComponent(await Adapter.urlForDownloadQuery(TestRequest, { cache: false })),
-      `${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=desc/?dateTime=2015-01-03/2015-01-04&metrics=m1,m2,r(p=123)&filters=d3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notin[""]&having=m1-gt[0]&format=json&_cache=false`,
+      `${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=desc/?dateTime=2015-01-03/2015-01-04T00:00:00.000&metrics=m1,m2,r(p=123)&filters=d3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notin[""]&having=m1-gt[0]&format=json&_cache=false`,
       'urlForDownloadQuery correctly built the URL for the provided request with the cache option'
     );
 
     assert.equal(
       decodeURIComponent(await Adapter.urlForDownloadQuery(TestRequest, { dataSourceName: 'bardTwo' })),
-      `${HOST2}/v1/data/table1/grain1/d1;show=id/d2;show=desc/?dateTime=2015-01-03/2015-01-04&metrics=m1,m2,r(p=123)&filters=d3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notin[""]&having=m1-gt[0]&format=json`,
+      `${HOST2}/v1/data/table1/grain1/d1;show=id/d2;show=desc/?dateTime=2015-01-03/2015-01-04T00:00:00.000&metrics=m1,m2,r(p=123)&filters=d3|id-in["v1","v2"],d4|id-in["v3","v4"],d5|id-notin[""]&having=m1-gt[0]&format=json`,
       'urlForDownloadQuery renders alternative host name if option is given'
     );
   });

--- a/packages/data/tests/unit/adapters/facts/elide-test.ts
+++ b/packages/data/tests/unit/adapters/facts/elide-test.ts
@@ -197,6 +197,7 @@ module('Unit | Adapter | facts/elide', function (hooks) {
       'Request with "not between" filter operator splits the filter into two correctly'
     );
 
+    debugger;
     assert.equal(
       adapter['dataQueryFromRequest']({
         table: 'myTable',
@@ -220,8 +221,10 @@ module('Unit | Adapter | facts/elide', function (hooks) {
       }),
       `{"query":"{ myTable(filter: \\"time=ge=('${moment()
         .subtract(1, 'month')
-        .format('YYYY-MM')}');time=le=('${moment().format('YYYY-MM')}')\\") { edges { node { time d1 } } } }"}`,
-      'Macros and durations in time-dimension filters are converted to date strings properly'
+        .format('YYYY-MM')}');time=le=('${moment()
+        .subtract(1, 'month')
+        .format('YYYY-MM')}')\\") { edges { node { time d1 } } } }"}`,
+      'Macros and durations in time-dimension filters are converted to date strings properly ([P1X, current] -> equals 1 X duration)'
     );
 
     assert.equal(
@@ -263,7 +266,7 @@ module('Unit | Adapter | facts/elide', function (hooks) {
             parameters: { grain: 'day' },
             type: 'timeDimension',
             operator: 'bet',
-            values: ['2020-05-05', '2020-05-09'],
+            values: ['2020-05-05', '2020-05-08'],
           },
         ],
         requestVersion: '2.0',

--- a/packages/data/tests/unit/adapters/facts/elide-test.ts
+++ b/packages/data/tests/unit/adapters/facts/elide-test.ts
@@ -197,7 +197,6 @@ module('Unit | Adapter | facts/elide', function (hooks) {
       'Request with "not between" filter operator splits the filter into two correctly'
     );
 
-    debugger;
     assert.equal(
       adapter['dataQueryFromRequest']({
         table: 'myTable',

--- a/packages/data/tests/unit/services/navi-facts-test.ts
+++ b/packages/data/tests/unit/services/navi-facts-test.ts
@@ -118,7 +118,7 @@ module('Unit | Service | Navi Facts', function (hooks) {
     assert.deepEqual(
       Service.getURL(TestRequest),
       `${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=id/?` +
-        'dateTime=2015-01-03%2F2015-01-04&metrics=m1%2Cm2&' +
+        'dateTime=2015-01-03%2F2015-01-04T00%3A00%3A00.000&metrics=m1%2Cm2&' +
         'filters=d3%7Cid-in%5B%22v1%22%2C%22v2%22%5D%2Cd4%7Cid-in%5B%22v3%22%2C%22v4%22%5D&having=m1-gt%5B0%5D&' +
         'format=json',
       'Service returns the url when requested'
@@ -127,7 +127,7 @@ module('Unit | Service | Navi Facts', function (hooks) {
     assert.deepEqual(
       Service.getURL(TestRequest, { format: 'jsonApi' }),
       `${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=id/?` +
-        'dateTime=2015-01-03%2F2015-01-04&metrics=m1%2Cm2&' +
+        'dateTime=2015-01-03%2F2015-01-04T00%3A00%3A00.000&metrics=m1%2Cm2&' +
         'filters=d3%7Cid-in%5B%22v1%22%2C%22v2%22%5D%2Cd4%7Cid-in%5B%22v3%22%2C%22v4%22%5D&having=m1-gt%5B0%5D&' +
         'format=jsonApi',
       'Service returns the url when requested with format'

--- a/packages/data/tests/unit/utils/classes/interval-test.ts
+++ b/packages/data/tests/unit/utils/classes/interval-test.ts
@@ -71,7 +71,13 @@ module('Unit | Utils | Interval Class', function () {
   });
 
   test('diffForTimePeriod', function (assert) {
-    assert.expect(6);
+    assert.expect(7);
+
+    assert.equal(
+      new Interval(new Duration('P1D'), moment.utc('2021-02-05')).diffForTimePeriod('day'),
+      1,
+      'Interval has 1 days for absolute day to 1 day ago'
+    );
 
     assert.equal(
       new Interval(new Duration('P7D'), 'current').diffForTimePeriod('day'),
@@ -80,19 +86,19 @@ module('Unit | Utils | Interval Class', function () {
     );
 
     assert.equal(
-      new Interval(moment('2014-10-10'), moment('2015-10-10')).diffForTimePeriod('day'),
+      new Interval(moment('2014-10-10'), moment('2015-10-09')).diffForTimePeriod('day'),
       365,
       'Interval has 365 days for a 1 year period'
     );
 
     assert.equal(
-      new Interval(moment('2015-11-09 00:00:00.000'), moment('2015-11-10 10:00:00.000')).diffForTimePeriod('hour'),
+      new Interval(moment('2015-11-09 00:00:00.000'), moment('2015-11-10 09:00:00.000')).diffForTimePeriod('hour'),
       34,
       'Interval has 34 hours for a 1 day 10 hour time period'
     );
 
     assert.equal(
-      new Interval(moment('2015-11-09'), moment('2015-11-10')).diffForTimePeriod('day'),
+      new Interval(moment('2015-11-09'), moment('2015-11-09')).diffForTimePeriod('day'),
       1,
       'Interval has 1 day for a 1 day period'
     );
@@ -104,7 +110,7 @@ module('Unit | Utils | Interval Class', function () {
     );
 
     assert.equal(
-      new Interval(moment('2015-11-10 10:00:00.000'), moment('2015-11-10 11:00:00.000')).diffForTimePeriod('hour'),
+      new Interval(moment('2015-11-10 10:00:00.000'), moment('2015-11-10 10:00:00.000')).diffForTimePeriod('hour'),
       1,
       'Interval has 1 hour for a 1 hour period'
     );
@@ -173,9 +179,9 @@ module('Unit | Utils | Interval Class', function () {
 
     assert.equal(moments.start.format(FORMAT), '2017-10-09', 'Start moment is at start of isoWeek');
 
-    assert.equal(moments.end.format(FORMAT), '2017-10-16', 'End moment is at start of next isoWeek');
+    assert.equal(moments.end.format(FORMAT), '2017-10-09', 'End moment is at start of next isoWeek');
 
-    moments = new Interval(start, end).asMomentsForTimePeriod('isoWeek', false);
+    moments = new Interval(start, end).asMomentsForTimePeriod('isoWeek');
 
     assert.ok(moments.start.isSame(moments.end), 'Start moment is same as end moment');
   });
@@ -250,7 +256,7 @@ module('Unit | Utils | Interval Class', function () {
 
     assert.equal(newInterval.start.format(FORMAT), '2017-10-09', 'Start moment is at start of isoWeek');
 
-    assert.equal(newInterval.end?.format(FORMAT), '2017-10-16', 'End moment is at start of isoWeek');
+    assert.equal(newInterval.end?.format(FORMAT), '2017-10-09', 'End moment is at start of isoWeek');
   });
 
   test('asStrings', function (assert) {

--- a/packages/data/tests/unit/utils/classes/interval-test.ts
+++ b/packages/data/tests/unit/utils/classes/interval-test.ts
@@ -1,7 +1,7 @@
 import Interval from 'navi-data/utils/classes/interval';
 import Duration from 'navi-data/utils/classes/duration';
 import { module, test } from 'qunit';
-import { getPeriodForGrain } from 'navi-data/utils/date';
+import { getPeriodForGrain, Grain } from 'navi-data/utils/date';
 import moment, { Moment } from 'moment';
 
 const FORMAT = 'YYYY-MM-DD';
@@ -184,6 +184,58 @@ module('Unit | Utils | Interval Class', function () {
     moments = new Interval(start, end).asMomentsForTimePeriod('isoWeek', false);
 
     assert.ok(moments.start.isSame(moments.end), 'Start moment is same as end moment');
+  });
+
+  test('asMomentsInclusive', function (assert) {
+    assert.expect(8);
+
+    const toInclusive = (startStr: string, endStr: string, grain: Grain) => {
+      const { start, end } = Interval.parseFromStrings(startStr, endStr).asMomentsInclusive(grain);
+      return [start.toISOString(), end.toISOString()];
+    };
+    const startStr = '2014-01-01';
+    const endStr = '2015-01-01';
+    const startValue = `${startStr}T00:00:00.000Z`;
+    assert.deepEqual(
+      toInclusive(startStr, endStr, 'second'),
+      [startValue, '2014-12-31T23:59:59.000Z'],
+      'End moment is inclusive of the second'
+    );
+    assert.deepEqual(
+      toInclusive(startStr, endStr, 'minute'),
+      [startValue, '2014-12-31T23:59:00.000Z'],
+      'End moment is inclusive of the minute'
+    );
+    assert.deepEqual(
+      toInclusive(startStr, endStr, 'hour'),
+      [startValue, '2014-12-31T23:00:00.000Z'],
+      'End moment is inclusive of the hour'
+    );
+    assert.deepEqual(
+      toInclusive(startStr, endStr, 'day'),
+      [startValue, '2014-12-31T00:00:00.000Z'],
+      'End moment is inclusive of the day'
+    );
+    assert.deepEqual(
+      toInclusive(startStr, endStr, 'isoWeek'),
+      ['2013-12-30T00:00:00.000Z', '2014-12-22T00:00:00.000Z'],
+      'End moment is inclusive of the isoWeek and aligned to isoWeek'
+    );
+    assert.deepEqual(
+      toInclusive(startStr, endStr, 'month'),
+      [startValue, '2014-12-01T00:00:00.000Z'],
+      'End moment is inclusive of the month'
+    );
+    assert.deepEqual(
+      toInclusive(startStr, endStr, 'quarter'),
+      [startValue, '2014-10-01T00:00:00.000Z'],
+      'End moment is inclusive of the quarter'
+    );
+    assert.deepEqual(
+      toInclusive(startStr, endStr, 'year'),
+      [startValue, '2014-01-01T00:00:00.000Z'],
+      'End moment is inclusive of the year'
+    );
   });
 
   test('makeEndExclusiveFor', function (assert) {

--- a/packages/data/tests/unit/utils/classes/interval-test.ts
+++ b/packages/data/tests/unit/utils/classes/interval-test.ts
@@ -98,7 +98,7 @@ module('Unit | Utils | Interval Class', function () {
     );
 
     assert.equal(
-      new Interval(moment('2015-11-09'), moment('2015-11-09')).diffForTimePeriod('day'),
+      new Interval(moment('2015-11-09'), moment('2015-11-10')).diffForTimePeriod('day'),
       1,
       'Interval has 1 day for a 1 day period'
     );
@@ -110,7 +110,7 @@ module('Unit | Utils | Interval Class', function () {
     );
 
     assert.equal(
-      new Interval(moment('2015-11-10 10:00:00.000'), moment('2015-11-10 10:00:00.000')).diffForTimePeriod('hour'),
+      new Interval(moment('2015-11-10 10:00:00.000'), moment('2015-11-10 11:00:00.000')).diffForTimePeriod('hour'),
       1,
       'Interval has 1 hour for a 1 hour period'
     );

--- a/packages/data/tests/unit/utils/classes/interval-test.ts
+++ b/packages/data/tests/unit/utils/classes/interval-test.ts
@@ -86,13 +86,13 @@ module('Unit | Utils | Interval Class', function () {
     );
 
     assert.equal(
-      new Interval(moment('2014-10-10'), moment('2015-10-09')).diffForTimePeriod('day'),
+      new Interval(moment('2014-10-10'), moment('2015-10-10')).diffForTimePeriod('day'),
       365,
       'Interval has 365 days for a 1 year period'
     );
 
     assert.equal(
-      new Interval(moment('2015-11-09 00:00:00.000'), moment('2015-11-10 09:00:00.000')).diffForTimePeriod('hour'),
+      new Interval(moment('2015-11-09 00:00:00.000'), moment('2015-11-10 10:00:00.000')).diffForTimePeriod('hour'),
       34,
       'Interval has 34 hours for a 1 day 10 hour time period'
     );
@@ -179,9 +179,9 @@ module('Unit | Utils | Interval Class', function () {
 
     assert.equal(moments.start.format(FORMAT), '2017-10-09', 'Start moment is at start of isoWeek');
 
-    assert.equal(moments.end.format(FORMAT), '2017-10-09', 'End moment is at start of next isoWeek');
+    assert.equal(moments.end.format(FORMAT), '2017-10-16', 'End moment is at start of next isoWeek');
 
-    moments = new Interval(start, end).asMomentsForTimePeriod('isoWeek');
+    moments = new Interval(start, end).asMomentsForTimePeriod('isoWeek', false);
 
     assert.ok(moments.start.isSame(moments.end), 'Start moment is same as end moment');
   });
@@ -256,7 +256,7 @@ module('Unit | Utils | Interval Class', function () {
 
     assert.equal(newInterval.start.format(FORMAT), '2017-10-09', 'Start moment is at start of isoWeek');
 
-    assert.equal(newInterval.end?.format(FORMAT), '2017-10-09', 'End moment is at start of isoWeek');
+    assert.equal(newInterval.end?.format(FORMAT), '2017-10-16', 'End moment is at start of isoWeek');
   });
 
   test('asStrings', function (assert) {

--- a/packages/reports/addon/components/filter-builders/time-dimension.ts
+++ b/packages/reports/addon/components/filter-builders/time-dimension.ts
@@ -60,7 +60,7 @@ export function intervalPeriodForGrain(grain: Grain): DateGrain {
  */
 export function valuesForOperator(
   filter: FilterFragment,
-  dateTimePeriod: Grain,
+  grain: Grain,
   newOperator?: InternalOperatorType
 ): TimeFilterValues {
   newOperator = newOperator || internalOperatorForValues(filter);
@@ -68,44 +68,45 @@ export function valuesForOperator(
   const startStr = prevValues[0] || 'P1D';
   let endStr = prevValues[1];
   if (!endStr) {
-    endStr = 'current';
+    endStr = 'next';
   }
 
   if (newOperator === OPERATORS.current) {
     return ['current', 'next'];
   } else if (newOperator === OPERATORS.lookback) {
     const interval = Interval.parseFromStrings(startStr, endStr);
-    const end = interval.asMomentsForTimePeriod(dateTimePeriod).end.utc(true);
-    let intervalTimePeriod = intervalPeriodForGrain(dateTimePeriod);
+    const end = interval.asMomentsForTimePeriod(grain).end;
+    let intervalTimePeriod = intervalPeriodForGrain(grain);
 
-    let intervalValue;
-    if (end.isSame(moment.utc().startOf(dateTimePeriod).utc(true))) {
+    let intervalValue = 1;
+    if (end.isSame(moment.utc().startOf(grain)
+          .subtract(1, getPeriodForGrain(grain))
+          .utc(true)
+      )) {
       // end is 'current', get lookback amount
-      intervalValue = interval.diffForTimePeriod(intervalTimePeriod);
-    } else {
-      intervalValue = 1;
+      intervalValue = interval.diffForTimePeriod(grain);
     }
+    intervalValue = Math.max(intervalValue, 1);
 
-    if (dateTimePeriod === 'quarter') {
+    if (grain === 'quarter') {
       // round to quarter
-      const quarters = Math.max(Math.floor(intervalValue / MONTHS_IN_QUARTER), 1);
-      intervalValue = quarters * MONTHS_IN_QUARTER;
+      intervalValue = intervalValue * MONTHS_IN_QUARTER;
     }
 
     const dateTimePeriodLabel = intervalTimePeriod[0].toUpperCase();
     return [`P${intervalValue}${dateTimePeriodLabel}`, 'current'];
   } else if (newOperator === OPERATORS.since) {
     const interval = Interval.parseFromStrings(startStr, endStr);
-    const { start } = interval.asMomentsForTimePeriod(dateTimePeriod);
+    const { start } = interval.asMomentsForTimePeriod(grain);
     return [start.utc(true).toISOString()];
   } else if (newOperator === OPERATORS.before) {
     const interval = Interval.parseFromStrings(startStr, endStr);
-    const { end } = interval.asMomentsForTimePeriod(dateTimePeriod);
-    return [end.utc(true).subtract(1, getPeriodForGrain(dateTimePeriod)).toISOString()];
+    const { end } = interval.asMomentsForTimePeriod(grain);
+    return [end.toISOString()];
   } else if (newOperator === OPERATORS.dateRange) {
     const interval = Interval.parseFromStrings(startStr, endStr);
-    const { start, end } = interval.asMomentsForTimePeriod(dateTimePeriod);
-    return [start.startOf('day').utc(true).toISOString(), end.startOf('day').utc(true).toISOString()];
+    const { start, end } = interval.asMomentsForTimePeriod(grain);
+    return [start.toISOString(), end.toISOString()];
   }
   warn(`No operator was found for the values '${prevValues.join(',')}'`, {
     id: 'time-dimension-filter-builder-no-operator',

--- a/packages/reports/addon/components/filter-values/time-dimension/base-interval.ts
+++ b/packages/reports/addon/components/filter-values/time-dimension/base-interval.ts
@@ -4,12 +4,10 @@
  */
 import { computed } from '@ember/object';
 import { Moment } from 'moment';
-import { getPeriodForGrain } from 'navi-data/utils/date';
 import Interval from 'navi-data/utils/classes/interval';
 //@ts-ignore
 import { formatDateRange } from 'navi-reports/helpers/format-interval-inclusive-inclusive';
 import BaseTimeDimensionFilter from './base';
-import moment from 'moment';
 
 export default class BaseIntervalComponent extends BaseTimeDimensionFilter {
   /**
@@ -20,11 +18,7 @@ export default class BaseIntervalComponent extends BaseTimeDimensionFilter {
     const { values } = this.args.filter;
     let [start, end] = values || [];
     if (start && end) {
-      const endMoment = moment.utc(end);
-      if (endMoment.isValid()) {
-        end = endMoment.add(1, getPeriodForGrain(this.grain)).toISOString();
-      }
-      return Interval.parseFromStrings(start, end);
+      return Interval.parseInclusive(start, end, this.grain);
     }
     return undefined;
   }
@@ -35,7 +29,7 @@ export default class BaseIntervalComponent extends BaseTimeDimensionFilter {
   @computed('interval', 'grain')
   get startDate(): Moment | undefined {
     const { interval, grain } = this;
-    return interval?.asMomentsForTimePeriod(grain).start;
+    return interval?.asMomentsInclusive(grain).start;
   }
 
   /**
@@ -53,11 +47,7 @@ export default class BaseIntervalComponent extends BaseTimeDimensionFilter {
   @computed('interval', 'grain')
   get endDate() {
     const { interval, grain } = this;
-    if (interval) {
-      let { end } = interval.asMomentsForTimePeriod(grain);
-      return end.subtract(1, getPeriodForGrain(grain));
-    }
-    return undefined;
+    return interval?.asMomentsInclusive(grain).end;
   }
 
   /**

--- a/packages/reports/addon/components/filter-values/time-dimension/base-interval.ts
+++ b/packages/reports/addon/components/filter-values/time-dimension/base-interval.ts
@@ -4,20 +4,26 @@
  */
 import { computed } from '@ember/object';
 import { Moment } from 'moment';
+import { getPeriodForGrain } from 'navi-data/utils/date';
 import Interval from 'navi-data/utils/classes/interval';
 //@ts-ignore
 import { formatDateRange } from 'navi-reports/helpers/format-interval-inclusive-inclusive';
 import BaseTimeDimensionFilter from './base';
+import moment from 'moment';
 
 export default class BaseIntervalComponent extends BaseTimeDimensionFilter {
   /**
    * The interval of the selected date range
    */
-  @computed('args.filter.values.[]')
+  @computed('args.filter.values.[]', 'grain')
   get interval(): Interval | undefined {
     const { values } = this.args.filter;
-    const [start, end] = values || [];
+    let [start, end] = values || [];
     if (start && end) {
+      const endMoment = moment.utc(end);
+      if (endMoment.isValid()) {
+        end = endMoment.add(1, getPeriodForGrain(this.grain)).toISOString();
+      }
       return Interval.parseFromStrings(start, end);
     }
     return undefined;
@@ -26,10 +32,10 @@ export default class BaseIntervalComponent extends BaseTimeDimensionFilter {
   /**
    * start of interval
    */
-  @computed('interval', 'calendarDateTimePeriod')
+  @computed('interval', 'grain')
   get startDate(): Moment | undefined {
-    const { interval, calendarDateTimePeriod } = this;
-    return interval?.asMomentsForTimePeriod(calendarDateTimePeriod).start.utc(true);
+    const { interval, grain } = this;
+    return interval?.asMomentsForTimePeriod(grain).start;
   }
 
   /**
@@ -44,13 +50,12 @@ export default class BaseIntervalComponent extends BaseTimeDimensionFilter {
   /**
    * end of interval
    */
-  @computed('interval', 'calendarDateTimePeriod')
+  @computed('interval', 'grain')
   get endDate() {
-    const { interval, calendarDateTimePeriod } = this;
+    const { interval, grain } = this;
     if (interval) {
-      let { end } = interval.asMomentsForTimePeriod(calendarDateTimePeriod);
-      end = end.clone().utc(true);
-      return end;
+      let { end } = interval.asMomentsForTimePeriod(grain);
+      return end.subtract(1, getPeriodForGrain(grain));
     }
     return undefined;
   }
@@ -58,26 +63,26 @@ export default class BaseIntervalComponent extends BaseTimeDimensionFilter {
   /**
    * start of interval
    */
-  @computed('endDate', 'calendarDateTimePeriod', 'calendarTriggerFormat')
+  @computed('endDate', 'grain', 'calendarTriggerFormat')
   get endDateText() {
-    const { endDate, calendarDateTimePeriod, calendarTriggerFormat } = this;
+    const { endDate, grain, calendarTriggerFormat } = this;
     if (!endDate) {
       return undefined;
     }
 
-    // TODO support calendarDateTimePeriod === 'week'
-    const end = calendarDateTimePeriod === 'isoWeek' ? endDate.clone().endOf('isoWeek') : endDate;
+    // TODO support grain === 'week'
+    const end = grain === 'isoWeek' ? endDate.clone().endOf('isoWeek') : endDate;
     return end.format(calendarTriggerFormat);
   }
 
   /**
    * The representation of the selected inclusive interval
    */
-  @computed('interval', 'calendarDateTimePeriod')
+  @computed('interval', 'grain')
   get dateRange(): string | undefined {
-    const { startDate, endDate, calendarDateTimePeriod } = this;
+    const { startDate, endDate, grain } = this;
     if (startDate && endDate) {
-      return formatDateRange(startDate, endDate, calendarDateTimePeriod);
+      return formatDateRange(startDate, endDate, grain);
     }
     return undefined;
   }

--- a/packages/reports/addon/components/filter-values/time-dimension/base-interval.ts
+++ b/packages/reports/addon/components/filter-values/time-dimension/base-interval.ts
@@ -1,10 +1,9 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2021, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import { computed } from '@ember/object';
 import { Moment } from 'moment';
-import { getPeriodForGrain } from 'navi-data/utils/date';
 import Interval from 'navi-data/utils/classes/interval';
 //@ts-ignore
 import { formatDateRange } from 'navi-reports/helpers/format-interval-inclusive-inclusive';
@@ -49,8 +48,8 @@ export default class BaseIntervalComponent extends BaseTimeDimensionFilter {
   get endDate() {
     const { interval, calendarDateTimePeriod } = this;
     if (interval) {
-      let { end } = interval.asMomentsForTimePeriod(calendarDateTimePeriod, false);
-      end = end.clone().subtract(1, getPeriodForGrain(calendarDateTimePeriod)).utc(true);
+      let { end } = interval.asMomentsForTimePeriod(calendarDateTimePeriod);
+      end = end.clone().utc(true);
       return end;
     }
     return undefined;

--- a/packages/reports/addon/components/filter-values/time-dimension/base.ts
+++ b/packages/reports/addon/components/filter-values/time-dimension/base.ts
@@ -20,20 +20,12 @@ export default class BaseTimeDimensionFilter extends Component<TimeDimensionFilt
 
   endPlaceholder = 'End';
 
-  @readOnly('args.filter.parameters.grain') dateTimePeriod!: Grain;
-
-  /**
-   * the active dateTimePeriod
-   */
-  @computed('dateTimePeriod')
-  get calendarDateTimePeriod() {
-    return this.dateTimePeriod;
-  }
+  @readOnly('args.filter.parameters.grain') grain!: Grain;
 
   /**
    * the datetime format to display based on the time grain
    */
-  @computed('calendarDateTimePeriod')
+  @computed('grain')
   get calendarTriggerFormat() {
     const dateMap: Partial<Record<Grain, string>> = {
       hour: 'MMM DD, YYYY',
@@ -42,7 +34,7 @@ export default class BaseTimeDimensionFilter extends Component<TimeDimensionFilt
       quarter: '[Q]Q YYYY',
       year: 'YYYY',
     };
-    return dateMap[this.calendarDateTimePeriod] || dateMap.day;
+    return dateMap[this.grain] || dateMap.day;
   }
 
   /**

--- a/packages/reports/addon/components/filter-values/time-dimension/current.hbs
+++ b/packages/reports/addon/components/filter-values/time-dimension/current.hbs
@@ -7,6 +7,6 @@
   {{/if}}
 {{else}}
   <div class="filter-values--current-period" ...attributes>
-    The current {{this.calendarDateTimePeriod}}. ({{this.dateRange}})
+    The current {{this.grain}}. ({{this.dateRange}})
   </div>
 {{/if}}

--- a/packages/reports/addon/components/filter-values/time-dimension/date.hbs
+++ b/packages/reports/addon/components/filter-values/time-dimension/date.hbs
@@ -8,7 +8,7 @@
 {{else}}
   <div class="filter-values--date-input" ...attributes>
     <DropdownDatePicker
-      @dateTimePeriod={{this.calendarDateTimePeriod}}
+      @dateTimePeriod={{this.grain}}
       @date={{this.date}}
       @onUpdate={{this.setDate}}
       class="filter-values--date-input__trigger"

--- a/packages/reports/addon/components/filter-values/time-dimension/lookback.hbs
+++ b/packages/reports/addon/components/filter-values/time-dimension/lookback.hbs
@@ -12,7 +12,7 @@
       @searchField="noop"
       @options={{this.ranges}}
       @selected={{filter-by 'isActive' this.ranges}}
-      @placeholder={{capitalize (concat this.calendarDateTimePeriod "s")}}
+      @placeholder={{capitalize (concat this.grain "s")}}
       @onChange={{pipe (pick 'interval') this.setPresetInterval}}
       @triggerClass="filter-values--lookback-trigger is-medium"
       @dropdownClass="filter-values--lookback-dropdown"
@@ -20,7 +20,7 @@
       @extra={{hash 
         value=this.lookback 
         onUpdate=this.setLookback
-        placeholder=(capitalize (concat this.calendarDateTimePeriod "s"))
+        placeholder=(capitalize (concat this.grain "s"))
       }}
       as |item|
     >

--- a/packages/reports/addon/components/filter-values/time-dimension/lookback.ts
+++ b/packages/reports/addon/components/filter-values/time-dimension/lookback.ts
@@ -25,12 +25,12 @@ export default class LookbackInput extends BaseIntervalComponent {
    */
   @computed('interval', 'dateTimePeriod')
   get lookback() {
-    const { interval, dateTimePeriod } = this;
+    const { interval, grain } = this;
     const { start } = interval?.asStrings() || {};
     if (start) {
       const duration = new Duration(start);
       const lookback = duration.getValue();
-      if (dateTimePeriod === 'quarter' && typeof lookback === 'number') {
+      if (grain === 'quarter' && typeof lookback === 'number') {
         return lookback / MONTHS_IN_QUARTER;
       }
       return lookback;
@@ -54,10 +54,10 @@ export default class LookbackInput extends BaseIntervalComponent {
   /**
    * list of ranges based on time grain supported look backs
    */
-  @computed('dateTimePeriod', 'interval')
+  @computed('grain', 'interval')
   get ranges() {
-    const { dateTimePeriod } = this;
-    const predefinedRanges = config.navi.predefinedIntervalRanges[dateTimePeriod] || [];
+    const { grain } = this;
+    const predefinedRanges = config.navi.predefinedIntervalRanges[grain] || [];
 
     return predefinedRanges.map((lookBack) => {
       const duration = new Duration(lookBack);
@@ -65,7 +65,7 @@ export default class LookbackInput extends BaseIntervalComponent {
       return {
         isActive: interval.isEqual(this.interval),
         interval,
-        text: this.formatDurationFromCurrent(duration, dateTimePeriod),
+        text: this.formatDurationFromCurrent(duration, grain),
       };
     });
   }
@@ -73,10 +73,10 @@ export default class LookbackInput extends BaseIntervalComponent {
   /**
    * human readable representation of the interval represented
    */
-  @computed('calendarDateTimePeriod', 'lookback', 'dateRange')
+  @computed('grain', 'lookback', 'dateRange')
   get dateDescription(): string {
-    const { calendarDateTimePeriod, dateRange, lookback } = this;
-    let datePeriod = calendarDateTimePeriod;
+    const { grain, dateRange, lookback } = this;
+    let datePeriod = grain;
     if (datePeriod === 'hour') {
       datePeriod = 'day';
     }
@@ -119,7 +119,7 @@ export default class LookbackInput extends BaseIntervalComponent {
     if (isEmpty(value) || lookback < 1) {
       return;
     }
-    const lookbackDuration = this.lookbackToDuration(lookback, this.dateTimePeriod);
+    const lookbackDuration = this.lookbackToDuration(lookback, this.grain);
     return this.setTimeStart(lookbackDuration);
   }
 

--- a/packages/reports/addon/components/filter-values/time-dimension/range.hbs
+++ b/packages/reports/addon/components/filter-values/time-dimension/range.hbs
@@ -17,6 +17,7 @@
         @size="medium"
         @iconBack="calendar-event"
         @iconBackClass="is-brand-300"
+        title={{object-at @filter.values 0}}
         value={{this.startDateText}} 
         readonly={{true}} 
         placeholder={{this.startPlaceholder}}
@@ -35,6 +36,7 @@
         @size="medium"
         @iconBack="calendar-event"
         @iconBackClass="is-brand-300"
+        title={{object-at @filter.values 1}}
         value={{this.endDateText}} 
         readonly={{true}} 
         placeholder={{this.endPlaceholder}}

--- a/packages/reports/addon/components/filter-values/time-dimension/range.hbs
+++ b/packages/reports/addon/components/filter-values/time-dimension/range.hbs
@@ -8,7 +8,7 @@
 {{else}}
   <div class="filter-values--date-range-input row" ...attributes>
     <DropdownDatePicker
-      @dateTimePeriod={{this.calendarDateTimePeriod}}
+      @dateTimePeriod={{this.grain}}
       @date={{this.startDate}}
       @onUpdate={{this.setTimeStartMoment}}
       class="filter-values--date-range-input__trigger filter-values--date-range-input__low-value col-3-7"
@@ -27,7 +27,7 @@
     <span class="filter-values--date-range-input__separator flex justify-content-center align-items-center col-1-7">and</span>
 
     <DropdownDatePicker
-      @dateTimePeriod={{this.calendarDateTimePeriod}}
+      @dateTimePeriod={{this.grain}}
       @date={{this.endDate}}
       @onUpdate={{this.setTimeEndMoment}}
       class="filter-values--date-range-input__trigger filter-values--date-range-input__high-value col-3-7"

--- a/packages/reports/addon/components/filter-values/time-dimension/range.ts
+++ b/packages/reports/addon/components/filter-values/time-dimension/range.ts
@@ -10,7 +10,6 @@
  */
 import { action } from '@ember/object';
 import { Moment } from 'moment';
-import { getPeriodForGrain } from 'navi-data/utils/date';
 import BaseIntervalComponent from './base-interval';
 
 export default class DimensionDateRange extends BaseIntervalComponent {
@@ -27,6 +26,6 @@ export default class DimensionDateRange extends BaseIntervalComponent {
    */
   @action
   setTimeEndMoment(end: Moment) {
-    this.setTimeEnd(end.add(1, getPeriodForGrain(this.dateTimePeriod)).toISOString());
+    this.setTimeEnd(end.toISOString());
   }
 }

--- a/packages/reports/addon/consumers/request/fili.ts
+++ b/packages/reports/addon/consumers/request/fili.ts
@@ -46,7 +46,7 @@ export default class FiliConsumer extends ActionConsumer {
             .subtract(1, getPeriodForGrain(newGrain))
             .toISOString();
         } else {
-          const interval = Interval.parseFromStrings(start, end).asMomentsForTimePeriod(newGrain);
+          const interval = Interval.parseInclusive(start, end, oldGrain).asMomentsInclusive(newGrain);
           start = interval.start.toISOString();
           end = interval.end.toISOString();
         }
@@ -56,7 +56,7 @@ export default class FiliConsumer extends ActionConsumer {
 
     const changeset = {
       parameters: { ...dateTimeFilter.parameters, grain: newGrain },
-      ...(values ? { values } : {})
+      ...(values ? { values } : {}),
     };
     this.requestActionDispatcher.dispatch(RequestActions.UPDATE_FILTER, route, dateTimeFilter, changeset);
   }
@@ -77,6 +77,7 @@ export default class FiliConsumer extends ActionConsumer {
       const { routeName } = route;
       const { request } = route.modelFor(routeName) as ReportModel;
       const { dateTimeFilter } = request;
+      debugger;
 
       const newGrain = changeset.parameters?.grain;
       // the grain was updated but no values were specified

--- a/packages/reports/addon/consumers/request/fili.ts
+++ b/packages/reports/addon/consumers/request/fili.ts
@@ -77,7 +77,6 @@ export default class FiliConsumer extends ActionConsumer {
       const { routeName } = route;
       const { request } = route.modelFor(routeName) as ReportModel;
       const { dateTimeFilter } = request;
-      debugger;
 
       const newGrain = changeset.parameters?.grain;
       // the grain was updated but no values were specified

--- a/packages/reports/addon/consumers/request/fili.ts
+++ b/packages/reports/addon/consumers/request/fili.ts
@@ -13,9 +13,11 @@ import { getDataSource } from 'navi-data/utils/adapter';
 import DimensionMetadataModel from 'navi-data/models/metadata/dimension';
 import { Parameters } from 'navi-data/adapters/facts/interface';
 import { valuesForOperator } from 'navi-reports/components/filter-builders/time-dimension';
-import { Grain } from 'navi-data/utils/date';
-import { BardTableMetadata } from 'navi-data/models/metadata/bard/table';
+import { getPeriodForGrain, Grain } from 'navi-data/utils/date';
+import { BardTableMetadata, GrainOrdering } from 'navi-data/models/metadata/bard/table';
 import FilterFragment from 'navi-core/models/bard-request-v2/fragments/filter';
+import moment from 'moment';
+import Interval from 'navi-data/utils/classes/interval';
 
 export default class FiliConsumer extends ActionConsumer {
   @service requestActionDispatcher!: RequestActionDispatcher;
@@ -29,6 +31,34 @@ export default class FiliConsumer extends ActionConsumer {
     const { type } = getDataSource(request.dataSource);
 
     return type === 'bard';
+  }
+
+  expandFilterInterval(route: Route, dateTimeFilter: FilterFragment, newGrain: Grain) {
+    let values;
+    if (dateTimeFilter.operator === 'bet') {
+      const oldGrain = dateTimeFilter.parameters.grain as Grain;
+      let [start, end] = dateTimeFilter.values as string[];
+      if (typeof end === 'string' && moment.utc(end).isValid()) {
+        if (GrainOrdering[oldGrain] > GrainOrdering[newGrain]) {
+          end = moment
+            .utc(end as string)
+            .add(1, getPeriodForGrain(oldGrain))
+            .subtract(1, getPeriodForGrain(newGrain))
+            .toISOString();
+        } else {
+          const interval = Interval.parseFromStrings(start, end).asMomentsForTimePeriod(newGrain);
+          start = interval.start.toISOString();
+          end = interval.end.toISOString();
+        }
+        values = [start, end];
+      }
+    }
+
+    const changeset = {
+      parameters: { ...dateTimeFilter.parameters, grain: newGrain },
+      ...(values ? { values } : {})
+    };
+    this.requestActionDispatcher.dispatch(RequestActions.UPDATE_FILTER, route, dateTimeFilter, changeset);
   }
 
   actions = {
@@ -49,6 +79,7 @@ export default class FiliConsumer extends ActionConsumer {
       const { dateTimeFilter } = request;
 
       const newGrain = changeset.parameters?.grain;
+      // the grain was updated but no values were specified
       if (dateTimeFilter === filterFragment && newGrain) {
         const values = valuesForOperator(dateTimeFilter, newGrain as Grain);
         const changeset = { values };
@@ -78,8 +109,7 @@ export default class FiliConsumer extends ActionConsumer {
       if (columnFragment.type === 'timeDimension' && parameterKey === 'grain') {
         // and there is a date time filter, update filter grain to match
         if (dateTimeFilter && dateTimeFilter.parameters.grain !== parameterValue) {
-          const changeset = { parameters: { ...dateTimeFilter.parameters, [parameterKey]: parameterValue } };
-          this.requestActionDispatcher.dispatch(RequestActions.UPDATE_FILTER, route, dateTimeFilter, changeset);
+          this.expandFilterInterval(route, dateTimeFilter, parameterValue as Grain);
         }
 
         // update all other date time grains to match
@@ -169,8 +199,7 @@ export default class FiliConsumer extends ActionConsumer {
         const grain = bardTableMetadata.timeGrains[0].id;
 
         if (dateTimeFilter.parameters.grain !== grain) {
-          const changeset = { parameters: { ...dateTimeFilter.parameters, grain } };
-          this.requestActionDispatcher.dispatch(RequestActions.UPDATE_FILTER, route, dateTimeFilter, changeset);
+          this.expandFilterInterval(route, dateTimeFilter, grain);
         }
       }
     },

--- a/packages/reports/addon/helpers/format-interval-inclusive-inclusive.js
+++ b/packages/reports/addon/helpers/format-interval-inclusive-inclusive.js
@@ -108,6 +108,7 @@ export function formatInterval([interval, timePeriod]) {
      * range for user display
      */
     let range = interval.asMomentsForTimePeriod(timePeriod);
+    range.end.subtract(1, timePeriod);
 
     return formatDateRange(range.start, range.end, timePeriod);
   }

--- a/packages/reports/addon/helpers/format-interval-inclusive-inclusive.js
+++ b/packages/reports/addon/helpers/format-interval-inclusive-inclusive.js
@@ -108,7 +108,6 @@ export function formatInterval([interval, timePeriod]) {
      * range for user display
      */
     let range = interval.asMomentsForTimePeriod(timePeriod);
-    range.end.subtract(1, timePeriod);
 
     return formatDateRange(range.start, range.end, timePeriod);
   }

--- a/packages/reports/tests/acceptance/multi-datasource-test.js
+++ b/packages/reports/tests/acceptance/multi-datasource-test.js
@@ -41,7 +41,7 @@ module('Acceptance | multi-datasource report builder', function (hooks) {
     await selectChoose('.filter-values--dimension-select__trigger', '1');
 
     await clickItemFilter('metric', 'Used Amount');
-    await fillIn('input.filter-values--value-input', '30');
+    await fillIn('input.filter-values--value-input', '1');
 
     await clickItem('dimension', 'Date Time');
     await clickItemFilter('dimension', 'Date Time');
@@ -64,7 +64,7 @@ module('Acceptance | multi-datasource report builder', function (hooks) {
     assert
       .dom('.filter-values--dimension-select__trigger')
       .containsText('× 1', 'Dimension filter input contains the right value');
-    assert.dom('.filter-values--value-input').hasValue('30', 'Having input has the right value');
+    assert.dom('.filter-values--value-input').hasValue('1', 'Having input has the right value');
 
     await click('.report-builder__container-header__filters-toggle');
     assert
@@ -73,7 +73,7 @@ module('Acceptance | multi-datasource report builder', function (hooks) {
 
     assert
       .dom('.report-builder__container--filters--collapsed')
-      .containsText('Used Amount greater than (>) 30', 'Collapsed filter contains right text');
+      .containsText('Used Amount greater than (>) 1', 'Collapsed filter contains right text');
     //check visualizations are showing up correctly
     assert.deepEqual(
       findAll('.table-widget__table-headers .table-header-cell__title').map((el) => el.textContent.trim()),

--- a/packages/reports/tests/acceptance/multi-datasource-test.js
+++ b/packages/reports/tests/acceptance/multi-datasource-test.js
@@ -117,44 +117,44 @@ module('Acceptance | multi-datasource report builder', function (hooks) {
     let originalFlag = config.navi.FEATURES.exportFileTypes;
     config.navi.FEATURES.exportFileTypes = ['csv', 'pdf', 'png'];
 
-    await visit('/reports/13/view');
+    await visit('/reports/12/view');
 
-    assert.dom('.navi-table-select-item').hasText('Network', 'Table selector shows correct table');
+    assert.dom('.navi-table-select-item').hasText('Inventory', 'Table selector shows correct table');
 
     //Check if filters meta data is displaying properly
     assert.deepEqual(
       findAll('.filter-builder__subject, .filter-builder__subject').map((el) => el.textContent.trim()),
-      ['Date Time (day)'],
+      ['Date Time (day)', 'Container (id)', 'Used Amount'],
       'Filter titles rendered correctly'
     );
 
     await click('.report-builder__container-header__filters-toggle');
     assert
       .dom('.report-builder__container--filters--collapsed')
-      .containsText('Filters Date Time (day) between', 'Collapsed filter has the right values');
+      .containsText('Container (id) equals 2 Used Amount greater than (>) 50', 'Collapsed filter has the right values');
 
     //check visualizations are showing up correctly
     assert.deepEqual(
       findAll('.table-widget__table-headers .table-header-cell__title').map((el) => el.textContent.trim()),
-      ['Date Time (day)', 'Ad Clicks', 'Property (id)'],
+      ['Date Time (day)', 'Container (id)', 'Display Currency (id)', 'Used Amount', 'Revenue (GIL)'],
       'Table displays correct header titles'
     );
     assert.dom('.table-widget__table .table-row-vc').exists('Table rows exist');
 
     await click('.visualization-toggle__option[title="Bar Chart"]');
-    assert.dom('.c3-axis-y-label').hasText('Ad Clicks', 'Bar chart has right Y axis label');
-    assert.dom('.c3-legend-item').containsText('114', 'Bar chart legend has right value');
+    assert.dom('.c3-axis-y-label').hasText('Used Amount', 'Bar chart has right Y axis label');
+    assert.dom('.c3-legend-item').containsText('2,ANG', 'Bar chart legend has right value');
 
     await click('.visualization-toggle__option[title="Line Chart"]');
-    assert.dom('.c3-axis-y-label').hasText('Ad Clicks', 'Line chart has right Y Axis label');
-    assert.dom('.c3-legend-item').containsText('114', 'Line chart has right legend value');
+    assert.dom('.c3-axis-y-label').hasText('Used Amount', 'Line chart has right Y Axis label');
+    assert.dom('.c3-legend-item').containsText('2,ANG', 'Line chart has right legend value');
 
     //check api url
     await click('.get-api__action-btn');
     assert
       .dom('.get-api__modal input')
       .hasValue(
-        'https://data.naviapp.io/v1/data/network/day/property;show=id/?dateTime=2015-10-02T00%3A00%3A00.000Z%2F2015-10-14T00%3A00%3A00.000Z&metrics=adClicks&format=json',
+        'https://data2.naviapp.io/v1/data/inventory/day/container;show=id/displayCurrency;show=id/?dateTime=P3D%2Fcurrent&metrics=usedAmount%2Crevenue(currency%3DGIL)&filters=container%7Cid-in%5B%222%22%5D&having=usedAmount-gt%5B50%5D&format=json',
         'shows api url from bardTwo datasource'
       );
 
@@ -164,7 +164,7 @@ module('Acceptance | multi-datasource report builder', function (hooks) {
       .dom(findAll('.multiple-format-export__dropdown a').filter((el) => el.textContent.trim() === 'CSV')[0])
       .hasAttribute(
         'href',
-        'https://data.naviapp.io/v1/data/network/day/property;show=id/?dateTime=2015-10-02T00%3A00%3A00.000Z%2F2015-10-14T00%3A00%3A00.000Z&metrics=adClicks&format=csv',
+        'https://data2.naviapp.io/v1/data/inventory/day/container;show=id/displayCurrency;show=id/?dateTime=P3D%2Fcurrent&metrics=usedAmount%2Crevenue(currency%3DGIL)&filters=container%7Cid-in%5B%222%22%5D&having=usedAmount-gt%5B50%5D&format=csv',
         'uses csv export from right datasource'
       );
 
@@ -178,12 +178,8 @@ module('Acceptance | multi-datasource report builder', function (hooks) {
       .dom('.report-builder__container--filters--collapsed')
       .doesNotIncludeText('Date Time (day)', 'Filters do not include dimension filters from external table');
 
-    assert.deepEqual(
-      await getAllSelected('dimension'),
-      ['Property'],
-      'Only property is selected once table is changed'
-    );
-    assert.deepEqual(await getAllSelected('metric'), ['Ad Clicks'], 'Only Ad Clicks is selected once table is changed');
+    assert.deepEqual(await getAllSelected('dimension'), [], 'All dimensions are removed when table is changed');
+    assert.deepEqual(await getAllSelected('metric'), [], 'All metrics are removed when table is changed');
 
     config.navi.FEATURES.exportFileTypes = originalFlag;
   });

--- a/packages/reports/tests/acceptance/report-test.js
+++ b/packages/reports/tests/acceptance/report-test.js
@@ -1707,7 +1707,7 @@ module('Acceptance | Navi Report', function (hooks) {
       .hasValue('Dec 29, 2014', 'Switching to week casts the date to match the start of the date time period');
     assert
       .dom('.filter-values--date-range-input__high-value input')
-      .hasValue('Feb 01, 2015', 'Switching to week casts the date to match the end of the date time period');
+      .hasValue('Jan 25, 2015', 'Switching to week casts the date to match the end of the date time period');
   });
 
   test('Date picker change interval type', async function (assert) {

--- a/packages/reports/tests/acceptance/report-test.js
+++ b/packages/reports/tests/acceptance/report-test.js
@@ -485,6 +485,7 @@ module('Acceptance | Navi Report', function (hooks) {
     await clickItem('metric', 'Ad Clicks');
     await clickItem('dimension', 'Date Time');
     await clickItemFilter('dimension', 'Date Time');
+    await selectChoose('.filter-builder__operator-trigger', 'In The Past');
     await click('.navi-report__run-btn');
 
     assert.ok(TempIdRegex.test(currentURL()), 'Creating a report brings user to /view route with a temp id');
@@ -1706,7 +1707,7 @@ module('Acceptance | Navi Report', function (hooks) {
       .hasValue('Dec 29, 2014', 'Switching to week casts the date to match the start of the date time period');
     assert
       .dom('.filter-values--date-range-input__high-value input')
-      .hasValue('Jan 25, 2015', 'Switching to week casts the date to match the end of the date time period');
+      .hasValue('Feb 01, 2015', 'Switching to week casts the date to match the end of the date time period');
   });
 
   test('Date picker change interval type', async function (assert) {
@@ -2115,7 +2116,7 @@ module('Acceptance | Navi Report', function (hooks) {
     await click(findAll('.number-format-dropdown__trigger')[1]); // open nav clicks dropdown
 
     const navClicksCell = () => find('.table-row-vc').querySelectorAll('.table-cell-content.metric')[1];
-    assert.dom(navClicksCell()).hasText('495.05', 'The original metric value has no formatting');
+    assert.dom(navClicksCell()).hasText('967.4', 'The original metric value has no formatting');
     assert.dom('.number-format-selector__radio-custom input').isChecked('The custom input is selected');
 
     find('.number-format-selector__radio-money input').checked = true; // change format to money
@@ -2124,6 +2125,6 @@ module('Acceptance | Navi Report', function (hooks) {
     assert.dom('.number-format-selector__radio-money input').isChecked('The money input is selected');
 
     await click('.number-format-dropdown');
-    assert.dom(navClicksCell()).hasText('$495.05', 'The metric is re-rendered in the money format');
+    assert.dom(navClicksCell()).hasText('$967.40', 'The metric is re-rendered in the money format');
   });
 });

--- a/packages/reports/tests/acceptance/report-test.js
+++ b/packages/reports/tests/acceptance/report-test.js
@@ -2116,7 +2116,7 @@ module('Acceptance | Navi Report', function (hooks) {
     await click(findAll('.number-format-dropdown__trigger')[1]); // open nav clicks dropdown
 
     const navClicksCell = () => find('.table-row-vc').querySelectorAll('.table-cell-content.metric')[1];
-    assert.dom(navClicksCell()).hasText('967.4', 'The original metric value has no formatting');
+    assert.dom(navClicksCell()).hasText('880.41', 'The original metric value has no formatting');
     assert.dom('.number-format-selector__radio-custom input').isChecked('The custom input is selected');
 
     find('.number-format-selector__radio-money input').checked = true; // change format to money
@@ -2125,6 +2125,6 @@ module('Acceptance | Navi Report', function (hooks) {
     assert.dom('.number-format-selector__radio-money input').isChecked('The money input is selected');
 
     await click('.number-format-dropdown');
-    assert.dom(navClicksCell()).hasText('$967.40', 'The metric is re-rendered in the money format');
+    assert.dom(navClicksCell()).hasText('$880.41', 'The metric is re-rendered in the money format');
   });
 });

--- a/packages/reports/tests/helpers/get-date-range.ts
+++ b/packages/reports/tests/helpers/get-date-range.ts
@@ -1,6 +1,6 @@
 import FilterFragment from 'navi-core/models/bard-request-v2/fragments/filter';
 import Interval from 'navi-data/utils/classes/interval';
-import { Grain } from 'navi-data/utils/date';
+import { getPeriodForGrain, Grain } from 'navi-data/utils/date';
 //@ts-ignore
 import { formatDateRange } from 'navi-reports/helpers/format-interval-inclusive-inclusive';
 
@@ -12,5 +12,6 @@ export function getDateRangeFormat(filter: FilterFragment) {
   const [startDate, endDate] = filter.values as string[];
   const timeGrain = filter.parameters.grain as Grain;
   const { start, end } = Interval.parseFromStrings(startDate, endDate).asMomentsForTimePeriod(timeGrain);
+  end.subtract(1, getPeriodForGrain(timeGrain));
   return formatDateRange(start, end, timeGrain);
 }

--- a/packages/reports/tests/helpers/get-date-range.ts
+++ b/packages/reports/tests/helpers/get-date-range.ts
@@ -1,6 +1,6 @@
 import FilterFragment from 'navi-core/models/bard-request-v2/fragments/filter';
 import Interval from 'navi-data/utils/classes/interval';
-import { getPeriodForGrain, Grain } from 'navi-data/utils/date';
+import { Grain } from 'navi-data/utils/date';
 //@ts-ignore
 import { formatDateRange } from 'navi-reports/helpers/format-interval-inclusive-inclusive';
 
@@ -12,6 +12,5 @@ export function getDateRangeFormat(filter: FilterFragment) {
   const [startDate, endDate] = filter.values as string[];
   const timeGrain = filter.parameters.grain as Grain;
   const { start, end } = Interval.parseFromStrings(startDate, endDate).asMomentsForTimePeriod(timeGrain);
-  end.subtract(1, getPeriodForGrain(timeGrain));
   return formatDateRange(start, end, timeGrain);
 }

--- a/packages/reports/tests/integration/components/filter-values/time-dimension/range-test.ts
+++ b/packages/reports/tests/integration/components/filter-values/time-dimension/range-test.ts
@@ -57,7 +57,7 @@ module('Integration | Component | filter-values/time-dimension/range', function 
 
     assert
       .dom('.filter-values--date-range-input__high-value input')
-      .hasValue('Dec 05, 2019', 'Placeholder text is inclusive end date');
+      .hasValue('Dec 06, 2019', 'Placeholder text is inclusive end date');
   });
 
   test('changing values', async function (this: TestContext, assert) {
@@ -72,7 +72,7 @@ module('Integration | Component | filter-values/time-dimension/range', function 
     const newStartStr = '2019-11-28';
 
     this.set('onUpdateFilter', ({ values }: Partial<FilterFragment>) => {
-      assert.deepEqual(values, [`${newStartStr}T00:00:00.000Z`, end], 'Updating start date works only updates start');
+      assert.deepEqual(values, [`${newStartStr}T00:00:00.000Z`, end], 'Updating start date changes value');
     });
 
     await click(`.ember-power-calendar-day[data-date="${newStartStr}"]`);
@@ -86,8 +86,8 @@ module('Integration | Component | filter-values/time-dimension/range', function 
     this.set('onUpdateFilter', ({ values }: Partial<FilterFragment>) => {
       assert.deepEqual(
         values,
-        [`${newStartStr}T00:00:00.000Z`, '2019-12-08T00:00:00.000Z'],
-        'Updating inclusive end date adds extra day'
+        [`${newStartStr}T00:00:00.000Z`, `${newEndStr}T00:00:00.000Z`],
+        'Updating end date changes value as [inclusive, inclusive]'
       );
     });
 
@@ -102,7 +102,7 @@ module('Integration | Component | filter-values/time-dimension/range', function 
 
     await render(TEMPLATE);
 
-    assert.dom().hasText('Jan 03, 2020 - Jan 09, 2020', 'Selected range text is rendered correctly');
+    assert.dom().hasText('Jan 03, 2020 - Jan 10, 2020', 'Selected range text is rendered correctly');
 
     this.set('filter', { values: [] });
 

--- a/packages/reports/tests/unit/components/filter-builders/time-dimension-test.ts
+++ b/packages/reports/tests/unit/components/filter-builders/time-dimension-test.ts
@@ -8,7 +8,7 @@ import TimeDimensionFilterBuilder, { valuesForOperator } from 'navi-reports/comp
 import StoreService from '@ember-data/store';
 import { TestContext } from 'ember-test-helpers';
 import RequestFragment from 'navi-core/models/bard-request-v2/request';
-import { getPeriodForGrain, Grain } from 'navi-data/utils/date';
+import { Grain } from 'navi-data/utils/date';
 
 let Request: RequestFragment;
 module('Unit | Component | filter-builders/time-dimension', function (hooks) {
@@ -159,9 +159,9 @@ module('Unit | Component | filter-builders/time-dimension', function (hooks) {
     );
 
     const intervalFor = (amount: string, grain: Grain): [string, string] => {
-      const { start, end } = Interval.parseFromStrings(amount, 'current').asMomentsForTimePeriod(grain);
+      const { start, end } = Interval.parseFromStrings(amount, 'current').asMomentsInclusive(grain);
       // subtract 1 to store filter values as inclusive
-      return [start.toISOString(), end.subtract(1, getPeriodForGrain(grain)).toISOString()];
+      return [start.toISOString(), end.toISOString()];
     };
     // 'inPast' tests
     filter.values = intervalFor('P4D', 'day');
@@ -245,8 +245,8 @@ module('Unit | Component | filter-builders/time-dimension', function (hooks) {
     );
 
     const currentInterval = (dateTimePeriod: Grain) => {
-      const { start, end } = Interval.parseFromStrings('current', 'next').asMomentsForTimePeriod(dateTimePeriod);
-      return [start.toISOString(), end.subtract(1, getPeriodForGrain(dateTimePeriod)).toISOString()];
+      const { start, end } = Interval.parseFromStrings('current', 'next').asMomentsInclusive(dateTimePeriod);
+      return [start.toISOString(), end.toISOString()];
     };
     // 'in' tests
 
@@ -290,11 +290,12 @@ module('Unit | Component | filter-builders/time-dimension', function (hooks) {
       'in translates P1D lookback to concrete'
     );
 
+    debugger;
     filter.values = ['P1W', '2018-12-31'];
     filter.parameters.grain = 'isoWeek';
     assert.deepEqual(
       valuesForOperator(filter, 'day', 'in'),
-      ['2018-12-31T00:00:00.000Z', '2018-12-31T00:00:00.000Z'],
+      ['2018-12-31T00:00:00.000Z', '2019-01-06T00:00:00.000Z'],
       'in translates P1W lookback to concrete'
     );
 
@@ -302,7 +303,7 @@ module('Unit | Component | filter-builders/time-dimension', function (hooks) {
     filter.parameters.grain = 'month';
     assert.deepEqual(
       valuesForOperator(filter, 'day', 'in'),
-      ['2019-01-01T00:00:00.000Z', '2019-01-01T00:00:00.000Z'],
+      ['2019-01-01T00:00:00.000Z', '2019-01-31T00:00:00.000Z'],
       'in translates P1M lookback to concrete'
     );
 
@@ -310,7 +311,7 @@ module('Unit | Component | filter-builders/time-dimension', function (hooks) {
     filter.parameters.grain = 'year';
     assert.deepEqual(
       valuesForOperator(filter, 'day', 'in'),
-      ['2019-01-01T00:00:00.000Z', '2019-01-01T00:00:00.000Z'],
+      ['2019-01-01T00:00:00.000Z', '2019-12-31T00:00:00.000Z'],
       'in translates P1Y lookback to concrete'
     );
 

--- a/packages/reports/tests/unit/components/filter-builders/time-dimension-test.ts
+++ b/packages/reports/tests/unit/components/filter-builders/time-dimension-test.ts
@@ -182,7 +182,7 @@ module('Unit | Component | filter-builders/time-dimension', function (hooks) {
     filter.values = intervalFor('P9M', 'quarter');
     assert.deepEqual(
       valuesForOperator(filter, 'quarter', 'inPast'),
-      ['P9M', 'current'],
+      ['P12M', 'current'],
       'Switching to inPast counts the quarters'
     );
 
@@ -221,7 +221,7 @@ module('Unit | Component | filter-builders/time-dimension', function (hooks) {
       'inPast maps invalid interval to P3M/current for day'
     );
 
-    filter.values = ['2019-01-01', '2020-03-02'];
+    filter.values = ['2019-01-01', '2019-03-02'];
     assert.deepEqual(
       valuesForOperator(filter, 'year', 'inPast'),
       ['P1Y', 'current'],
@@ -230,7 +230,7 @@ module('Unit | Component | filter-builders/time-dimension', function (hooks) {
 
     const currentInterval = (dateTimePeriod: Grain) => {
       const { start, end } = Interval.parseFromStrings('current', 'next').asMomentsForTimePeriod(dateTimePeriod);
-      return [start.utc(true).toISOString(), end.utc(true).toISOString()];
+      return [start.toISOString(), end.toISOString()];
     };
     // 'in' tests
 
@@ -265,28 +265,28 @@ module('Unit | Component | filter-builders/time-dimension', function (hooks) {
     filter.values = ['P1D', '2019-01-01'];
     assert.deepEqual(
       valuesForOperator(filter, 'day', 'in'),
-      ['2018-12-31T00:00:00.000Z', '2019-01-01T00:00:00.000Z'],
+      ['2019-01-01T00:00:00.000Z', '2019-01-01T00:00:00.000Z'],
       'in translates P1D lookback to concrete'
     );
 
-    filter.values = ['P1W', '2019-01-01'];
+    filter.values = ['P1W', '2018-12-31'];
     assert.deepEqual(
       valuesForOperator(filter, 'day', 'in'),
-      ['2018-12-25T00:00:00.000Z', '2019-01-01T00:00:00.000Z'],
+      ['2018-12-31T00:00:00.000Z', '2018-12-31T00:00:00.000Z'],
       'in translates P1W lookback to concrete'
     );
 
     filter.values = ['P1M', '2019-01-01'];
     assert.deepEqual(
       valuesForOperator(filter, 'day', 'in'),
-      ['2018-12-01T00:00:00.000Z', '2019-01-01T00:00:00.000Z'],
+      ['2019-01-01T00:00:00.000Z', '2019-01-01T00:00:00.000Z'],
       'in translates P1M lookback to concrete'
     );
 
     filter.values = ['P1Y', '2019-01-01'];
     assert.deepEqual(
       valuesForOperator(filter, 'day', 'in'),
-      ['2018-01-01T00:00:00.000Z', '2019-01-01T00:00:00.000Z'],
+      ['2019-01-01T00:00:00.000Z', '2019-01-01T00:00:00.000Z'],
       'in translates P1Y lookback to concrete'
     );
 

--- a/packages/reports/tests/unit/consumers/request/fili-test.ts
+++ b/packages/reports/tests/unit/consumers/request/fili-test.ts
@@ -80,9 +80,11 @@ module('Unit | Consumer | request fili', function (hooks) {
       'When the filter grain is updated, another request to update the filter values is fired off'
     );
 
+    const newValues = ['2020-12-28T00:00:00.000Z', '2021-02-22T00:00:00.000Z'];
+    request.dateTimeFilter!.values = newValues;
     assert.deepEqual(
       dispatchedActionArgs,
-      [request.dateTimeFilter, { values: ['2020-12-28T00:00:00.000Z', '2021-02-01T00:00:00.000Z'] }],
+      [request.dateTimeFilter, { values: newValues }],
       'UPDATE_FILTER is dispatched with the updated values for the filter'
     );
 
@@ -93,7 +95,7 @@ module('Unit | Consumer | request fili', function (hooks) {
     request.dateTimeFilter!.parameters.grain = 'day';
 
     consumer.send(RequestActions.UPDATE_FILTER, { modelFor }, request.dateTimeFilter, {
-      parameters: { grain: 'isoWeek' }
+      parameters: { grain: 'isoWeek' },
     });
     assert.deepEqual(
       dispatchedActions,
@@ -405,7 +407,7 @@ module('Unit | Consumer | request fili', function (hooks) {
       dispatchedActionArgs,
       [
         request.dateTimeFilter,
-        { parameters: { grain: 'hour' }, values: ['2021-01-01T00:00:00.000Z', '2021-02-28T23:00:00.000Z'] }
+        { parameters: { grain: 'hour' }, values: ['2021-01-01T00:00:00.000Z', '2021-02-28T23:00:00.000Z'] },
       ],
       'UPDATE_FILTER is dispatched with the lowest grain for the date time'
     );

--- a/packages/reports/tests/unit/consumers/request/fili-test.ts
+++ b/packages/reports/tests/unit/consumers/request/fili-test.ts
@@ -85,6 +85,27 @@ module('Unit | Consumer | request fili', function (hooks) {
       [request.dateTimeFilter, { values: ['2020-12-28T00:00:00.000Z', '2021-02-01T00:00:00.000Z'] }],
       'UPDATE_FILTER is dispatched with the updated values for the filter'
     );
+
+    dispatchedActions.length = 0;
+    dispatchedActionArgs.length = 0;
+
+    request.dateTimeFilter!.values = ['P1D', 'current'];
+    request.dateTimeFilter!.parameters.grain = 'day';
+
+    consumer.send(RequestActions.UPDATE_FILTER, { modelFor }, request.dateTimeFilter, {
+      parameters: { grain: 'isoWeek' }
+    });
+    assert.deepEqual(
+      dispatchedActions,
+      [RequestActions.UPDATE_FILTER],
+      'When the filter grain is updated, another request to update the filter values is fired off'
+    );
+
+    assert.deepEqual(
+      dispatchedActionArgs,
+      [request.dateTimeFilter, { values: ['P1W', 'current'] }],
+      'UPDATE_FILTER is dispatched with the updated values for the filter'
+    );
   });
 
   test('DID_ADD_COLUMN', function (assert) {
@@ -382,7 +403,10 @@ module('Unit | Consumer | request fili', function (hooks) {
 
     assert.deepEqual(
       dispatchedActionArgs,
-      [request.dateTimeFilter, { parameters: { grain: 'hour' } }],
+      [
+        request.dateTimeFilter,
+        { parameters: { grain: 'hour' }, values: ['2021-01-01T00:00:00.000Z', '2021-02-28T23:00:00.000Z'] }
+      ],
       'UPDATE_FILTER is dispatched with the lowest grain for the date time'
     );
   });

--- a/packages/reports/tests/unit/helpers/format-interval-inclusive-inclusive-test.js
+++ b/packages/reports/tests/unit/helpers/format-interval-inclusive-inclusive-test.js
@@ -14,11 +14,7 @@ module('Unit | Helper | format interval inclusive inclusive', function () {
   test('Undefined interval and time period', function (assert) {
     assert.expect(2);
 
-    assert.equal(
-      formatInterval([moment(new Interval('current', 'current')), null]),
-      '',
-      'No time period returns empty string'
-    );
+    assert.equal(formatInterval([new Interval('current', 'current'), null]), '', 'No time period returns empty string');
 
     assert.equal(formatInterval([null, 'week']), '', 'No interval returns empty string');
   });
@@ -26,12 +22,12 @@ module('Unit | Helper | format interval inclusive inclusive', function () {
   test('Formatting start and end', function (assert) {
     assert.expect(1);
 
-    let interval = new Interval(new Duration('P4W'), moment('10-14-2014', FORMAT)),
+    let interval = new Interval(new Duration('P3W'), moment.utc('10-07-2014', FORMAT)),
       formattedString = formatInterval([interval, 'isoWeek']);
 
     assert.equal(
       formattedString,
-      'Sep 15, 2014 - Oct 12, 2014',
+      'Sep 22, 2014 - Oct 12, 2014',
       'Interval was converted to inclusive end date and was correctly formatted'
     );
   });

--- a/packages/reports/tests/unit/helpers/format-interval-inclusive-inclusive-test.js
+++ b/packages/reports/tests/unit/helpers/format-interval-inclusive-inclusive-test.js
@@ -22,12 +22,12 @@ module('Unit | Helper | format interval inclusive inclusive', function () {
   test('Formatting start and end', function (assert) {
     assert.expect(1);
 
-    let interval = new Interval(new Duration('P3W'), moment.utc('10-07-2014', FORMAT)),
+    let interval = new Interval(new Duration('P4W'), moment.utc('10-14-2014', FORMAT)),
       formattedString = formatInterval([interval, 'isoWeek']);
 
     assert.equal(
       formattedString,
-      'Sep 22, 2014 - Oct 12, 2014',
+      'Sep 15, 2014 - Oct 12, 2014',
       'Interval was converted to inclusive end date and was correctly formatted'
     );
   });


### PR DESCRIPTION
## Description
Converts [inclusive, exclusive) v1 filters to [inclusive, inclusive] for v2

## Proposed Changes
- Use ISO String to store date filter values

## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
