### PR TITLE
Request constraints

### DIFF
--- a/packages/core/app/styles/navi-core/variables/colors.less
+++ b/packages/core/app/styles/navi-core/variables/colors.less
@@ -95,6 +95,7 @@
 
 @navi-notification-success-background-color: #00b777;
 @navi-notification-info-background-color: @navi-blue-500;
+@navi-notification-warning-background-color: @navi-yellow;
 @navi-notification-failure-background-color: @navi-red-400;
 
 @navi-disabled-element-background-color: @navi-gray-200;

--- a/packages/core/app/styles/navi-core/variables/colors.less
+++ b/packages/core/app/styles/navi-core/variables/colors.less
@@ -95,7 +95,6 @@
 
 @navi-notification-success-background-color: #00b777;
 @navi-notification-info-background-color: @navi-blue-500;
-@navi-notification-warning-background-color: @navi-yellow;
 @navi-notification-failure-background-color: @navi-red-400;
 
 @navi-disabled-element-background-color: @navi-gray-200;

--- a/packages/dashboards/addon/templates/dashboards/dashboard/widgets/widget.hbs
+++ b/packages/dashboards/addon/templates/dashboards/dashboard/widgets/widget.hbs
@@ -128,7 +128,7 @@
         @openFilters={{route-action "openFilters"}}
         @onAddColumn={{update-report-action "ADD_COLUMN_WITH_PARAMS"}}
         @onRemoveColumn={{update-report-action "REMOVE_COLUMN_FRAGMENT"}}
-        @onToggleFilter={{update-report-action "TOGGLE_FILTER"}}
+        @onAddFilter={{update-report-action "ADD_FILTER"}}
         @onRenameColumn={{update-report-action "RENAME_COLUMN_FRAGMENT"}}
         @onReorderColumn={{update-report-action "REORDER_COLUMN_FRAGMENT"}}
         @onUpdateColumnParam={{update-report-action "UPDATE_COLUMN_FRAGMENT_WITH_PARAMS"}}

--- a/packages/dashboards/tests/acceptance/dashboards-test.js
+++ b/packages/dashboards/tests/acceptance/dashboards-test.js
@@ -6,7 +6,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { Response } from 'ember-cli-mirage';
 import { selectChoose } from 'ember-power-select/test-support';
-import { clickItem, clickItemFilter } from 'navi-reports/test-support/report-builder';
+import { clickItem } from 'navi-reports/test-support/report-builder';
 import $ from 'jquery';
 
 let confirm;
@@ -388,7 +388,6 @@ module('Acceptance | Dashboards', function (hooks) {
     await click('.add-widget__new-btn');
 
     // Fill out request
-    await clickItemFilter('dimension', 'Date Time');
     await selectChoose('.filter-builder__operator-trigger', 'In The Past');
     await clickItem('dimension', 'Date Time');
     await selectChoose('.navi-column-config-item__parameter-trigger', 'Day');
@@ -422,7 +421,6 @@ module('Acceptance | Dashboards', function (hooks) {
     await click('.add-widget__new-btn');
 
     // Fill out request
-    await clickItemFilter('dimension', 'Date Time');
     await selectChoose('.filter-builder__operator-trigger', 'In The Past');
     await clickItem('dimension', 'Date Time');
     await selectChoose('.navi-column-config-item__parameter-trigger', 'Day');
@@ -510,7 +508,6 @@ module('Acceptance | Dashboards', function (hooks) {
     await visit('/dashboards/1/widgets/new');
 
     // Build Request
-    await clickItemFilter('dimension', 'Date Time');
     await selectChoose('.filter-builder__operator-trigger', 'In The Past');
     await clickItem('dimension', 'Date Time');
     await selectChoose('.navi-column-config-item__parameter-trigger', 'Day');
@@ -697,7 +694,6 @@ module('Acceptance | Dashboards', function (hooks) {
     await click('.add-widget__new-btn');
 
     // Fill out request
-    await clickItemFilter('dimension', 'Date Time');
     await selectChoose('.filter-builder__operator-trigger', 'In The Past');
     await clickItem('dimension', 'Date Time');
     await selectChoose('.navi-column-config-item__parameter-trigger', 'Day');

--- a/packages/dashboards/tests/acceptance/mutli-datasource-dashboards-test.js
+++ b/packages/dashboards/tests/acceptance/mutli-datasource-dashboards-test.js
@@ -3,7 +3,7 @@ import { visit, click, findAll, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest, test } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { selectChoose } from 'ember-power-select/test-support';
-import { clickItem, clickItemFilter } from 'navi-reports/test-support/report-builder';
+import { clickItem } from 'navi-reports/test-support/report-builder';
 
 module('Acceptance | Multi datasource Dashboard', function (hooks) {
   setupApplicationTest(hooks);
@@ -65,7 +65,6 @@ module('Acceptance | Multi datasource Dashboard', function (hooks) {
     await selectChoose('.navi-table-select__trigger', 'Inventory');
     await clickItem('dimension', 'Date Time');
     await selectChoose('.navi-column-config-item__parameter-trigger', 'Day');
-    await clickItemFilter('dimension', 'Date Time');
     await selectChoose('.filter-builder__operator-trigger', 'Current');
     await clickItem('dimension', 'Container');
     await clickItem('metric', 'Used Amount');

--- a/packages/data/addon/mirage/routes/bard-meta.js
+++ b/packages/data/addon/mirage/routes/bard-meta.js
@@ -63,6 +63,9 @@ export default function () {
         if (table.name === 'tableB') {
           timeGrains.shift();
         }
+        if (table.name === 'tableC') {
+          timeGrains.pop();
+        }
 
         return Object.assign({}, table, { timeGrains });
       });

--- a/packages/data/addon/models/metadata/request-constraint.ts
+++ b/packages/data/addon/models/metadata/request-constraint.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2021, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ *
+ * A collection of function parameters that has a one to many relationship to columns
+ */
+import EmberObject from '@ember/object';
+import { RequestV2 } from 'navi-data/adapters/facts/interface';
+import { matches } from 'lodash-es';
+
+type ConstrainableProperties = 'filters' | 'columns';
+
+type ExistenceConstraintForType<Type extends ConstrainableProperties> = {
+  property: Type;
+  matches: Pick<RequestV2[Type][number], 'type' | 'field'>;
+};
+type ExistenceConstraint = ExistenceConstraintForType<'filters'> | ExistenceConstraintForType<'columns'>;
+
+export interface RequestConstraintMetadataPayload {
+  id: string;
+  name: string;
+  description?: string;
+  type: 'existence';
+  constraint: ExistenceConstraint;
+  source: string;
+}
+export type RequestConstraintMetadata = RequestConstraintMetadataPayload;
+
+export default class RequestConstraintMetadataModel
+  extends EmberObject
+  implements RequestConstraintMetadataPayload, RequestConstraintMetadata {
+  id!: string;
+  name!: string;
+  description?: string | undefined;
+  type!: 'existence';
+  constraint!: ExistenceConstraint;
+  source!: string;
+
+  isSatisfied(request: RequestV2): boolean {
+    const { property, matches: partialProperties } = this.constraint;
+    return request[property].some(matches(partialProperties));
+  }
+}
+
+declare module './registry' {
+  export default interface MetadataModelRegistry {
+    requestConstraint: RequestConstraintMetadataModel;
+  }
+}

--- a/packages/data/addon/models/metadata/table.ts
+++ b/packages/data/addon/models/metadata/table.ts
@@ -9,6 +9,7 @@ import DimensionMetadataModel from './dimension';
 import TimeDimensionMetadataModel from './time-dimension';
 import CARDINALITY_SIZES from '../../utils/enums/cardinality-sizes';
 import NaviMetadataService from 'navi-data/services/navi-metadata';
+import RequestConstraintMetadataModel from './request-constraint';
 
 // Shape passed to model constructor
 export interface TableMetadataPayload {
@@ -21,6 +22,7 @@ export interface TableMetadataPayload {
   metricIds: string[];
   dimensionIds: string[];
   timeDimensionIds: string[];
+  requestConstraintIds: string[];
   source: string;
   tags?: string[];
 }
@@ -35,6 +37,7 @@ export interface TableMetadata {
   metrics: MetricMetadataModel[];
   dimensions: DimensionMetadataModel[];
   timeDimensions: TimeDimensionMetadataModel[];
+  requestConstraints: RequestConstraintMetadataModel[];
   source: string;
   tags: string[];
 }
@@ -99,6 +102,11 @@ export default class TableMetadataModel extends EmberObject implements TableMeta
   timeDimensionIds!: string[];
 
   /**
+   * @property {string[]} requestConstraintIds - array of request constraint ids
+   */
+  requestConstraintIds!: string[];
+
+  /**
    * @param {Metric[]} metrics
    */
   get metrics(): MetricMetadataModel[] {
@@ -118,6 +126,12 @@ export default class TableMetadataModel extends EmberObject implements TableMeta
   get timeDimensions(): TimeDimensionMetadataModel[] {
     return this.timeDimensionIds
       .map((id) => this.naviMetadata.getById('timeDimension', id, this.source))
+      .filter(isPresent);
+  }
+
+  get requestConstraints(): RequestConstraintMetadataModel[] {
+    return this.requestConstraintIds
+      .map(id => this.naviMetadata.getById('requestConstraint', id, this.source))
       .filter(isPresent);
   }
 

--- a/packages/data/addon/models/metadata/table.ts
+++ b/packages/data/addon/models/metadata/table.ts
@@ -131,7 +131,7 @@ export default class TableMetadataModel extends EmberObject implements TableMeta
 
   get requestConstraints(): RequestConstraintMetadataModel[] {
     return this.requestConstraintIds
-      .map(id => this.naviMetadata.getById('requestConstraint', id, this.source))
+      .map((id) => this.naviMetadata.getById('requestConstraint', id, this.source))
       .filter(isPresent);
   }
 

--- a/packages/data/addon/serializers/metadata/bard.ts
+++ b/packages/data/addon/serializers/metadata/bard.ts
@@ -9,7 +9,7 @@ import MetricMetadataModel, { MetricMetadataPayload } from 'navi-data/models/met
 import DimensionMetadataModel, { DimensionMetadataPayload } from 'navi-data/models/metadata/dimension';
 import TimeDimensionMetadataModel, { TimeDimensionMetadataPayload } from 'navi-data/models/metadata/time-dimension';
 import RequestConstraintMetadataModel, {
-  RequestConstraintMetadataPayload
+  RequestConstraintMetadataPayload,
 } from 'navi-data/models/metadata/request-constraint';
 import NaviMetadataSerializer, { MetadataModelMap, EverythingMetadataPayload } from './base';
 import { assert } from '@ember/debug';
@@ -341,9 +341,9 @@ export default class BardMetadataSerializer extends NaviMetadataSerializer {
         property: 'columns',
         matches: {
           type: 'timeDimension',
-          field: id
-        }
-      }
+          field: id,
+        },
+      },
     };
     return this.requestConstraintFactory.create(payload);
   }
@@ -368,9 +368,9 @@ export default class BardMetadataSerializer extends NaviMetadataSerializer {
         property: 'filters',
         matches: {
           type: 'timeDimension',
-          field: id
-        }
-      }
+          field: id,
+        },
+      },
     };
     return this.requestConstraintFactory.create(payload);
   }

--- a/packages/data/addon/serializers/metadata/base.ts
+++ b/packages/data/addon/serializers/metadata/base.ts
@@ -8,6 +8,7 @@ import MetricMetadataModel from 'navi-data/models/metadata/metric';
 import DimensionMetadataModel from 'navi-data/models/metadata/dimension';
 import TimeDimensionMetadataModel from 'navi-data/models/metadata/time-dimension';
 import ColumnFunctionMetadataModel from 'navi-data/models/metadata/column-function';
+import RequestConstraintMetadataModel from 'navi-data/models/metadata/request-constraint';
 import { getOwner } from '@ember/application';
 
 export interface EverythingMetadataPayload {
@@ -16,11 +17,13 @@ export interface EverythingMetadataPayload {
   dimensions: DimensionMetadataModel[];
   timeDimensions: TimeDimensionMetadataModel[];
   columnFunctions?: ColumnFunctionMetadataModel[];
+  requestConstraints: RequestConstraintMetadataModel[];
 }
 
 export interface MetadataModelMap {
   everything: EverythingMetadataPayload;
   table: TableMetadataModel[];
+  requestConstraint: RequestConstraintMetadataModel[];
   metric: MetricMetadataModel[];
   dimension: DimensionMetadataModel[];
   timeDimension: TimeDimensionMetadataModel[];
@@ -33,6 +36,7 @@ export default abstract class NaviMetadataSerializer extends EmberObject {
   protected metricFactory = getOwner(this).factoryFor('model:metadata/metric');
   protected dimensionFactory = getOwner(this).factoryFor('model:metadata/dimension');
   protected timeDimensionFactory = getOwner(this).factoryFor('model:metadata/time-dimension');
+  protected requestConstraintFactory = getOwner(this).factoryFor('model:metadata/request-constraint');
   protected tableFactory = getOwner(this).factoryFor('model:metadata/table');
   protected columnFunctionFactory = getOwner(this).factoryFor('model:metadata/column-function');
 

--- a/packages/data/addon/serializers/metadata/elide.ts
+++ b/packages/data/addon/serializers/metadata/elide.ts
@@ -102,6 +102,7 @@ export default class ElideMetadataSerializer extends NaviMetadataSerializer {
         metricIds: [],
         dimensionIds: [],
         timeDimensionIds: [],
+        requestConstraintIds: [],
         source,
       };
 
@@ -133,6 +134,7 @@ export default class ElideMetadataSerializer extends NaviMetadataSerializer {
       dimensions,
       timeDimensions,
       columnFunctions,
+      requestConstraints: [],
     };
   }
 

--- a/packages/data/addon/services/navi-metadata.ts
+++ b/packages/data/addon/services/navi-metadata.ts
@@ -56,10 +56,11 @@ export default class NaviMetadataService extends Service {
    */
   private loadEverythingMetadataIntoKeg(payload: EverythingMetadataPayload, dataSourceName: string) {
     this.loadMetadataForType('table', payload.tables, dataSourceName);
+    this.loadMetadataForType('metric', payload.metrics, dataSourceName);
     this.loadMetadataForType('dimension', payload.dimensions, dataSourceName);
     this.loadMetadataForType('timeDimension', payload.timeDimensions, dataSourceName);
     this.loadMetadataForType('columnFunction', payload.columnFunctions || [], dataSourceName);
-    this.loadMetadataForType('metric', payload.metrics, dataSourceName);
+    this.loadMetadataForType('requestConstraint', payload.requestConstraints, dataSourceName);
     this.loadedDataSources.add(dataSourceName);
   }
 

--- a/packages/data/app/models/metadata/request-constraint.js
+++ b/packages/data/app/models/metadata/request-constraint.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-data/models/metadata/request-constraint';

--- a/packages/data/tests/unit/adapters/metadata/bard-test.ts
+++ b/packages/data/tests/unit/adapters/metadata/bard-test.ts
@@ -47,7 +47,7 @@ module('Unit | Adapter | metadata/bard', function (hooks) {
         { dimensions: 31, grains: 7, metrics: 42, name: 'tableA' },
         { dimensions: 31, grains: 6, metrics: 42, name: 'tableB' },
         { dimensions: 31, grains: 7, metrics: 42, name: 'protected' },
-        { dimensions: 31, grains: 7, metrics: 33, name: 'tableC' },
+        { dimensions: 31, grains: 6, metrics: 33, name: 'tableC' },
       ],
       '`fetchEverything` correctly requested all datasource metadata'
     );

--- a/packages/data/tests/unit/models/metadata/bard/table-test.ts
+++ b/packages/data/tests/unit/models/metadata/bard/table-test.ts
@@ -20,6 +20,7 @@ module('Unit | Model | metadata/bard/table', function (hooks) {
       dimensionIds: ['age'],
       timeDimensionIds: ['orderDate'],
       timeGrainIds: ['day', 'month', 'week'],
+      requestConstraintIds: [],
       hasAllGrain: false,
       source: 'bardOne',
       tags: ['DISPLAY'],

--- a/packages/data/tests/unit/models/metadata/request-constraint-test.ts
+++ b/packages/data/tests/unit/models/metadata/request-constraint-test.ts
@@ -1,0 +1,81 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import Pretender, { Server } from 'pretender';
+import { TestContext } from 'ember-test-helpers';
+// @ts-ignore
+import metadataRoutes from 'navi-data/test-support/helpers/metadata-routes';
+import RequestConstraintMetadataModel, {
+  RequestConstraintMetadataPayload
+} from 'navi-data/models/metadata/request-constraint';
+import { RequestV2 } from 'navi-data/adapters/facts/interface';
+
+let server: Server;
+let Payload: RequestConstraintMetadataPayload;
+let RequestConstraint: RequestConstraintMetadataModel;
+
+module('Unit | Model | metadata/request constraint', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(async function(this: TestContext) {
+    server = new Pretender(metadataRoutes);
+    await this.owner.lookup('service:navi-metadata').loadMetadata();
+
+    Payload = {
+      id: 'normalizer-generated:requestConstraint(filters=tableName.dateTime)',
+      name: 'Date Time Filter',
+      description: 'The request has a Date Time filter that specifies an interval.',
+      type: 'existence',
+      constraint: { property: 'filters', matches: { type: 'timeDimension', field: 'tableName.dateTime' } },
+      source: 'bardOne'
+    };
+
+    RequestConstraint = RequestConstraintMetadataModel.create(this.owner.ownerInjection(), Payload);
+  });
+
+  hooks.afterEach(function() {
+    server.shutdown();
+  });
+
+  test('it properly hydrates properties', function(assert) {
+    assert.expect(6);
+
+    assert.deepEqual(RequestConstraint.id, Payload.id, 'id property is hydrated properly');
+
+    assert.deepEqual(RequestConstraint.name, Payload.name, 'name property was properly hydrated');
+
+    assert.deepEqual(RequestConstraint.description, Payload.description, 'description property was properly hydrated');
+
+    assert.deepEqual(RequestConstraint.type, Payload.type, 'type property was properly hydrated');
+
+    assert.deepEqual(RequestConstraint.constraint, Payload.constraint, 'constraint property was properly hydrated');
+
+    assert.deepEqual(RequestConstraint.source, Payload.source, 'source property was properly hydrated');
+  });
+
+  test('constraint can be satisfied', function(assert) {
+    assert.expect(2);
+
+    const EmptyRequest: RequestV2 = {
+      table: '',
+      dataSource: '',
+      requestVersion: '2.0',
+      limit: null,
+      columns: [],
+      filters: [],
+      sorts: []
+    };
+
+    assert.notOk(
+      RequestConstraint.isSatisfied(EmptyRequest),
+      'request constraint is not satisfied when there is no matching filter'
+    );
+
+    assert.ok(
+      RequestConstraint.isSatisfied({
+        ...EmptyRequest,
+        filters: [{ type: 'timeDimension', field: 'tableName.dateTime', parameters: {}, operator: 'bet', values: [] }]
+      }),
+      'request constraint is satisfied when there is a matching filter'
+    );
+  });
+});

--- a/packages/data/tests/unit/models/metadata/request-constraint-test.ts
+++ b/packages/data/tests/unit/models/metadata/request-constraint-test.ts
@@ -5,7 +5,7 @@ import { TestContext } from 'ember-test-helpers';
 // @ts-ignore
 import metadataRoutes from 'navi-data/test-support/helpers/metadata-routes';
 import RequestConstraintMetadataModel, {
-  RequestConstraintMetadataPayload
+  RequestConstraintMetadataPayload,
 } from 'navi-data/models/metadata/request-constraint';
 import { RequestV2 } from 'navi-data/adapters/facts/interface';
 
@@ -13,10 +13,10 @@ let server: Server;
 let Payload: RequestConstraintMetadataPayload;
 let RequestConstraint: RequestConstraintMetadataModel;
 
-module('Unit | Model | metadata/request constraint', function(hooks) {
+module('Unit | Model | metadata/request constraint', function (hooks) {
   setupTest(hooks);
 
-  hooks.beforeEach(async function(this: TestContext) {
+  hooks.beforeEach(async function (this: TestContext) {
     server = new Pretender(metadataRoutes);
     await this.owner.lookup('service:navi-metadata').loadMetadata();
 
@@ -26,17 +26,17 @@ module('Unit | Model | metadata/request constraint', function(hooks) {
       description: 'The request has a Date Time filter that specifies an interval.',
       type: 'existence',
       constraint: { property: 'filters', matches: { type: 'timeDimension', field: 'tableName.dateTime' } },
-      source: 'bardOne'
+      source: 'bardOne',
     };
 
     RequestConstraint = RequestConstraintMetadataModel.create(this.owner.ownerInjection(), Payload);
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(function () {
     server.shutdown();
   });
 
-  test('it properly hydrates properties', function(assert) {
+  test('it properly hydrates properties', function (assert) {
     assert.expect(6);
 
     assert.deepEqual(RequestConstraint.id, Payload.id, 'id property is hydrated properly');
@@ -52,7 +52,7 @@ module('Unit | Model | metadata/request constraint', function(hooks) {
     assert.deepEqual(RequestConstraint.source, Payload.source, 'source property was properly hydrated');
   });
 
-  test('constraint can be satisfied', function(assert) {
+  test('constraint can be satisfied', function (assert) {
     assert.expect(2);
 
     const EmptyRequest: RequestV2 = {
@@ -62,7 +62,7 @@ module('Unit | Model | metadata/request constraint', function(hooks) {
       limit: null,
       columns: [],
       filters: [],
-      sorts: []
+      sorts: [],
     };
 
     assert.notOk(
@@ -73,7 +73,7 @@ module('Unit | Model | metadata/request constraint', function(hooks) {
     assert.ok(
       RequestConstraint.isSatisfied({
         ...EmptyRequest,
-        filters: [{ type: 'timeDimension', field: 'tableName.dateTime', parameters: {}, operator: 'bet', values: [] }]
+        filters: [{ type: 'timeDimension', field: 'tableName.dateTime', parameters: {}, operator: 'bet', values: [] }],
       }),
       'request constraint is satisfied when there is a matching filter'
     );

--- a/packages/data/tests/unit/models/metadata/table-test.ts
+++ b/packages/data/tests/unit/models/metadata/table-test.ts
@@ -1,7 +1,10 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import TableMetadataModel, { TableMetadataPayload } from 'navi-data/models/metadata/table';
+import KegService from 'navi-data/services/keg';
 
-let Payload, Model, Keg, TableFactory;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let Payload: TableMetadataPayload, Model: TableMetadataModel, Keg: KegService, TableFactory: any;
 
 module('Unit | Metadata Model | Table', function (hooks) {
   setupTest(hooks);
@@ -16,6 +19,7 @@ module('Unit | Metadata Model | Table', function (hooks) {
       metricIds: ['pv'],
       dimensionIds: ['age'],
       timeDimensionIds: ['orderDate'],
+      requestConstraintIds: ['constraint'],
       isFact: true,
       source: 'bardOne',
       tags: ['DISPLAY'],
@@ -49,12 +53,24 @@ module('Unit | Metadata Model | Table', function (hooks) {
       { namespace: 'bardOne' }
     );
     Keg.push(
-      'metadata/time-dimension',
+      'metadata/timeDimension',
       {
         id: 'orderDate',
         name: 'Order Date',
         description: 'Order Date',
         category: 'category',
+        source: 'bardOne',
+      },
+      { namespace: 'bardOne' }
+    );
+    Keg.push(
+      'metadata/requestConstraint',
+      {
+        id: 'constraint',
+        name: 'Constraint',
+        description: 'Constraint',
+        type: 'existence',
+        constraint: {},
         source: 'bardOne',
       },
       { namespace: 'bardOne' }
@@ -70,7 +86,7 @@ module('Unit | Metadata Model | Table', function (hooks) {
   });
 
   test('it properly hydrates properties', function (assert) {
-    assert.expect(11);
+    assert.expect(12);
 
     const {
       id,
@@ -81,6 +97,7 @@ module('Unit | Metadata Model | Table', function (hooks) {
       metricIds,
       dimensionIds,
       timeDimensionIds,
+      requestConstraintIds,
       source,
       isFact,
       tags,
@@ -94,6 +111,11 @@ module('Unit | Metadata Model | Table', function (hooks) {
     assert.deepEqual(metricIds, Payload.metricIds, 'metricIds property is hydrated properly');
     assert.deepEqual(dimensionIds, Payload.dimensionIds, 'dimensionIds property is hydrated properly');
     assert.deepEqual(timeDimensionIds, Payload.timeDimensionIds, 'timeDimensionIds property is hydrated properly');
+    assert.deepEqual(
+      requestConstraintIds,
+      Payload.requestConstraintIds,
+      'requestConstraintIds property is hydrated properly'
+    );
     assert.equal(source, Payload.source, 'source property is hydrated properly');
     assert.deepEqual(tags, Payload.tags, 'tags property is hydrated properly');
     assert.deepEqual(isFact, Payload.isFact, 'isFact property is hydrated properly');
@@ -125,6 +147,16 @@ module('Unit | Metadata Model | Table', function (hooks) {
       Model.timeDimensions[0],
       Keg.getById('metadata/timeDimension', 'orderDate', 'bardOne'),
       'The Order date time-dimension is properly hydrated'
+    );
+  });
+
+  test('Request Constraint in Table', function (assert) {
+    assert.expect(1);
+
+    assert.equal(
+      Model.requestConstraints[0],
+      Keg.getById('metadata/requestConstraint', 'constraint', 'bardOne'),
+      'The requestConstraint is properly hydrated'
     );
   });
 });

--- a/packages/data/tests/unit/serializers/metadata/bard-test.ts
+++ b/packages/data/tests/unit/serializers/metadata/bard-test.ts
@@ -14,7 +14,7 @@ import MetricMetadataModel, { MetricMetadataPayload } from 'navi-data/models/met
 import ColumnFunctionMetadataModel, { ColumnFunctionMetadataPayload } from 'navi-data/models/metadata/column-function';
 import BardTableMetadataModel, { BardTableMetadataPayload } from 'navi-data/models/metadata/bard/table';
 import RequestConstraintMetadataModel, {
-  RequestConstraintMetadataPayload
+  RequestConstraintMetadataPayload,
 } from 'navi-data/models/metadata/request-constraint';
 
 const Payload: RawEverythingPayload = {
@@ -405,7 +405,7 @@ const TablePayloads: BardTableMetadataPayload[] = [
     timeGrainIds: ['day', 'isoWeek'],
     requestConstraintIds: [
       'normalizer-generated:requestConstraint(filters=secondTable.dateTime)',
-      'normalizer-generated:requestConstraint(columns=secondTable.dateTime)'
+      'normalizer-generated:requestConstraint(columns=secondTable.dateTime)',
     ],
     hasAllGrain: false,
   },
@@ -775,7 +775,7 @@ const RequestConstraintPayloads: RequestConstraintMetadataPayload[] = [
     description: 'The request has a Date Time filter that specifies an interval.',
     type: 'existence',
     constraint: { property: 'filters', matches: { type: 'timeDimension', field: 'tableName.dateTime' } },
-    source: 'bardOne'
+    source: 'bardOne',
   },
   {
     id: 'normalizer-generated:requestConstraint(filters=secondTable.dateTime)',
@@ -783,7 +783,7 @@ const RequestConstraintPayloads: RequestConstraintMetadataPayload[] = [
     description: 'The request has a Date Time filter that specifies an interval.',
     type: 'existence',
     constraint: { property: 'filters', matches: { type: 'timeDimension', field: 'secondTable.dateTime' } },
-    source: 'bardOne'
+    source: 'bardOne',
   },
   {
     id: 'normalizer-generated:requestConstraint(columns=secondTable.dateTime)',
@@ -791,8 +791,8 @@ const RequestConstraintPayloads: RequestConstraintMetadataPayload[] = [
     description: 'The request has a Date Time column.',
     type: 'existence',
     constraint: { property: 'columns', matches: { type: 'timeDimension', field: 'secondTable.dateTime' } },
-    source: 'bardOne'
-  }
+    source: 'bardOne',
+  },
 ];
 
 let Serializer: BardMetadataSerializer;
@@ -817,7 +817,7 @@ module('Unit | Serializer | metadata/bard', function (hooks) {
     ColumnFunctions = ColumnFunctionPayloads.map((p) =>
       ColumnFunctionMetadataModel.create(this.owner.ownerInjection(), p)
     );
-    RequestConstraints = RequestConstraintPayloads.map(p =>
+    RequestConstraints = RequestConstraintPayloads.map((p) =>
       RequestConstraintMetadataModel.create(this.owner.ownerInjection(), p)
     );
   });

--- a/packages/data/tests/unit/serializers/metadata/elide-test.ts
+++ b/packages/data/tests/unit/serializers/metadata/elide-test.ts
@@ -238,6 +238,7 @@ module('Unit | Serializer | metadata/elide', function (hooks) {
         metricIds: ['tableA.m1'],
         dimensionIds: ['tableA.d1', 'tableA.d2'],
         timeDimensionIds: ['tableA.td1'],
+        requestConstraintIds: [],
         source: 'bardOne',
       },
       {
@@ -250,6 +251,7 @@ module('Unit | Serializer | metadata/elide', function (hooks) {
         metricIds: ['tableB.m2', 'tableB.m3'],
         dimensionIds: ['tableB.d1', 'tableB.d2'],
         timeDimensionIds: [],
+        requestConstraintIds: [],
         source: 'bardOne',
       },
     ];
@@ -426,6 +428,7 @@ module('Unit | Serializer | metadata/elide', function (hooks) {
         columnFunctions: expectedColumnFunctionsPayloads.map((p) =>
           ColumnFunctionMetadataModel.create(this.owner.ownerInjection(), p)
         ),
+        requestConstraints: [],
       },
       'Table 0'
     );

--- a/packages/reports/addon-test-support/report-builder.js
+++ b/packages/reports/addon-test-support/report-builder.js
@@ -105,7 +105,7 @@ export async function getItem(type, query, itemText) {
  * @param {Object} instance - the test or application instance
  * @param {String} type - a valid selector for grouped lists
  * @param {String} query - The query to type in the search bar
- * @param {String|undefined} itemText - The text content of the element to click
+ * @param {String|void} itemText - The text content of the element to click
  */
 export async function clickItem(type, query, itemText) {
   assert('clickItem must be passed an accepted type', isAcceptedType(type));

--- a/packages/reports/addon/components/filter-builders/base.hbs
+++ b/packages/reports/addon/components/filter-builders/base.hbs
@@ -2,6 +2,7 @@
 {{#if @isCollapsed}}
   <span class="filter-builder" ...attributes>
     <FilterBuilders::Collapsed
+      @isRequired={{@isRequired}}
       @filter={{@filter}}
       @selectedValueBuilder={{this.selectedValueBuilder}}
       @request={{@request}}
@@ -28,6 +29,7 @@
     <div class="filter-builder__values xs-col-1-1 sm-col-1-1 col-3-5">
       {{#let (component this.selectedValueBuilder.component) as |ValuesComponent|}}
         <ValuesComponent
+          @isRequired={{@isRequired}}
           @filter={{@filter}}
           @request={{@request}}
           @onUpdateFilter={{@onUpdateFilter}}

--- a/packages/reports/addon/components/filter-builders/base.ts
+++ b/packages/reports/addon/components/filter-builders/base.ts
@@ -1,10 +1,9 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2021, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Base class for filter builders.
  */
-
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import FilterFragment from 'navi-core/models/bard-request-v2/fragments/filter';
@@ -14,6 +13,7 @@ import { Filter, FilterOperator } from 'navi-data/adapters/facts/interface';
 import { isEqual } from 'lodash-es';
 
 interface BaseFilterBuilderArgs {
+  isRequired: boolean;
   filter: FilterFragment;
   request: RequestFragment;
   onUpdateFilter(changeSet: Partial<FilterFragment>): void;

--- a/packages/reports/addon/components/filter-builders/time-dimension.ts
+++ b/packages/reports/addon/components/filter-builders/time-dimension.ts
@@ -51,6 +51,8 @@ export function intervalPeriodForGrain(grain: Grain): DateGrain {
   return period;
 }
 
+type FilterLike = { values: FilterFragment['values']; operator: FilterFragment['operator'] };
+
 /**
  * Converts an Interval to a format suitable to the newOperator while retaining as much information as possible
  * e.g. ([P7D, current], day, in) -> [2020-01-01,2020-01-08]
@@ -59,7 +61,7 @@ export function intervalPeriodForGrain(grain: Grain): DateGrain {
  * @param newOperator - the operator to build values for
  */
 export function valuesForOperator(
-  filter: FilterFragment,
+  filter: FilterLike,
   grain: Grain,
   newOperator?: InternalOperatorType
 ): TimeFilterValues {
@@ -106,7 +108,7 @@ export function valuesForOperator(
   return [];
 }
 
-export function internalOperatorForValues(filter: FilterFragment): InternalOperatorType {
+export function internalOperatorForValues(filter: FilterLike): InternalOperatorType {
   const { values, operator } = filter;
   const [startStr, endStr] = values as string[];
 

--- a/packages/reports/addon/components/filter-builders/time-dimension.ts
+++ b/packages/reports/addon/components/filter-builders/time-dimension.ts
@@ -51,7 +51,7 @@ export function intervalPeriodForGrain(grain: Grain): DateGrain {
   return period;
 }
 
-type FilterLike = { values: FilterFragment['values']; operator: FilterFragment['operator'] };
+type FilterLike = Pick<FilterFragment, 'values' | 'parameters' | 'operator'>;
 
 /**
  * Converts an Interval to a format suitable to the newOperator while retaining as much information as possible

--- a/packages/reports/addon/components/filter-collection.hbs
+++ b/packages/reports/addon/components/filter-collection.hbs
@@ -5,6 +5,7 @@
       {{#if @isCollapsed}}
         <FilterBuilder
           class="filter-collection--collapsed-item"
+          @isRequired={{filter.isRequired}}
           @filter={{filter.fragment}}
           @request={{@request}}
           @isCollapsed={{true}}
@@ -19,12 +20,13 @@
               @size="medium"
               @icon="minus-circle"
               @iconOnly={{true}}
-              disable={{filter.required}}
+              disabled={{filter.isRequired}}
               {{on "click" (fn @onRemoveFilter filter.fragment)}}
             />
           </div>
           <FilterBuilder
             class="filter-collection__builder row flex-1"
+            @isRequired={{filter.isRequired}}
             @filter={{filter.fragment}}
             @request={{@request}}
             @onUpdateFilter={{fn @onUpdateFilter filter.fragment}}

--- a/packages/reports/addon/components/filter-collection.ts
+++ b/packages/reports/addon/components/filter-collection.ts
@@ -33,7 +33,7 @@ export default class FilterCollection extends Component<FilterCollectionArgs> {
   get filters(): FilterItem[] {
     const { request } = this.args;
     const requiredFilters = this.requestConstrainer.getConstrainedProperties(request).filters || new Set();
-    return [...request.dimensionFilters, ...request.metricFilters].map(fragment => ({
+    return [...request.dimensionFilters, ...request.metricFilters].map((fragment) => ({
       type: this.getFilterType(fragment),
       isRequired: requiredFilters.has(fragment),
       fragment,

--- a/packages/reports/addon/components/navi-column-config.hbs
+++ b/packages/reports/addon/components/navi-column-config.hbs
@@ -14,7 +14,7 @@
             @onOpenColumn={{this.openColumn}}
             @onRemoveColumn={{fn @onRemoveColumn column.fragment}}
             @cloneColumn={{fn this.cloneColumn column}}
-            @toggleColumnFilter={{fn this.onToggleFilter column.fragment}}
+            @onAddFilter={{fn this.onAddFilter column.fragment}}
             @onRenameColumn={{fn @onRenameColumn column.fragment}}
             @onUpdateColumnParam={{fn @onUpdateColumnParam column.fragment}}
           />

--- a/packages/reports/addon/components/navi-column-config/base.hbs
+++ b/packages/reports/addon/components/navi-column-config/base.hbs
@@ -8,11 +8,12 @@
         {{!-- TODO: Favorites are not supported yet --}}
         {{!-- <NaviIcon @icon="star-o" class="navi-column-config-base__star-icon" role="button" /> --}}
         <NaviIcon @icon="clone" class="navi-column-config-base__clone-icon" role="button" {{on "click" @cloneColumn}} />
-        <NaviIcon
+        <DenaliIcon
+          @icon="filter-add"
+          @size="small"
           class="navi-column-config-base__filter-icon {{if @column.isFiltered "navi-column-config-base__filter-icon--active"}}"
-          @icon="filter"
           role="button"
-          {{on "click" @toggleColumnFilter}}
+          {{on "click" @onAddFilter}}
         />
       </span>
     </div>

--- a/packages/reports/addon/components/navi-column-config/base.hbs
+++ b/packages/reports/addon/components/navi-column-config/base.hbs
@@ -11,7 +11,7 @@
         <DenaliIcon
           @icon="filter-add"
           @size="small"
-          class="navi-column-config-base__filter-icon {{if @column.isFiltered "navi-column-config-base__filter-icon--active"}}"
+          class="navi-column-config-base__filter-icon"
           role="button"
           {{on "click" @onAddFilter}}
         />

--- a/packages/reports/addon/components/navi-column-config/base.ts
+++ b/packages/reports/addon/components/navi-column-config/base.ts
@@ -7,7 +7,7 @@
  * Usage:
  *  <NaviColumnConfig::Base
  *    @column={{this.column}}
- *    @toggleColumnFilter={{this.toggleColumnFilter}}
+ *    @onAddFilter={{this.onAddFilter}}
  *    @onRenameColumn={{this.onRenameColumn}}
  *    @onUpdateColumnParam={{this.onUpdateColumnParam}}
  *  />

--- a/packages/reports/addon/components/navi-column-config/item.js
+++ b/packages/reports/addon/components/navi-column-config/item.js
@@ -12,7 +12,7 @@
  *    @onOpenColumn={{this.openColumn}}
  *    @onRemoveColumn={{fn @onRemoveColumn column.fragment}}
  *    @cloneColumn={{fn this.cloneColumn column}}
- *    @toggleColumnFilter={{fn @onToggleFilter column}}
+ *    @onAddFilter={{fn @onAddFilter column}}
  *    @onRenameColumn={{fn @onRenameColumn column.fragment}}
  *    @onUpdateColumnParam={{fn @onUpdateColumnParam column.fragment}}
  *  />

--- a/packages/reports/addon/components/report-builder.js
+++ b/packages/reports/addon/components/report-builder.js
@@ -7,7 +7,6 @@ import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed, action } from '@ember/object';
 import layout from '../templates/components/report-builder';
-import { canonicalizeMetric } from 'navi-data/utils/metric';
 import { layout as templateLayout, tagName } from '@ember-decorators/component';
 import { A } from '@ember/array';
 
@@ -63,35 +62,10 @@ export default class ReportBuilderComponent extends Component {
   }
 
   /**
-   * @action onToggleDimFilter
-   * @param {Object} dimension
+   * @action onAddFilter
    */
   @action
-  onToggleDimFilter(dimension) {
-    this._expandFilters(() => this.request.dimensionFilters.find((f) => f.field === dimension));
-  }
-
-  /**
-   * @action onToggleMetricFilter
-   * @param {Object} metric
-   */
-  @action
-  onToggleMetricFilter(metric) {
-    this._expandFilters(() => this.request.metricFilters.find((f) => f.field === metric.name));
-  }
-
-  /**
-   * @action onToggleParameterizedMetricFilter
-   * @param {Object} metric
-   * @param {Object} parameters
-   */
-  @action
-  onToggleParameterizedMetricFilter(metric, parameters) {
-    //TODO clean me up
-    this._expandFilters(() =>
-      this.request.metricFilters.find(
-        (filter) => filter.canonicalName === canonicalizeMetric({ metric: metric.name, parameters })
-      )
-    );
+  onAddFilter() {
+    this._expandFilters(() => true);
   }
 }

--- a/packages/reports/addon/consumers/request/constraint.ts
+++ b/packages/reports/addon/consumers/request/constraint.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+import { inject as service } from '@ember/service';
+import ActionConsumer from 'navi-core/consumers/action-consumer';
+import Route from '@ember/routing/route';
+import RequestActionDispatcher, { RequestActions } from 'navi-reports/services/request-action-dispatcher';
+import TableMetadataModel from 'navi-data//models/metadata/table';
+import RequestConstrainer from 'navi-reports/services/request-constrainer';
+
+export default class ConstraintConsumer extends ActionConsumer {
+  @service requestActionDispatcher!: RequestActionDispatcher;
+  @service requestConstrainer!: RequestConstrainer;
+
+  actions = {
+    /**
+     * @action DID_UPDATE_TABLE
+     * @param route - route that has a model that contains a request property
+     * @param table - table that the request is updated with
+     */
+    [RequestActions.DID_UPDATE_TABLE](this: ConstraintConsumer, route: Route, _table: TableMetadataModel) {
+      this.requestConstrainer.constrain(route);
+    }
+  };
+}

--- a/packages/reports/addon/consumers/request/constraint.ts
+++ b/packages/reports/addon/consumers/request/constraint.ts
@@ -21,6 +21,6 @@ export default class ConstraintConsumer extends ActionConsumer {
      */
     [RequestActions.DID_UPDATE_TABLE](this: ConstraintConsumer, route: Route, _table: TableMetadataModel) {
       this.requestConstrainer.constrain(route);
-    }
+    },
   };
 }

--- a/packages/reports/addon/consumers/request/constraint.ts
+++ b/packages/reports/addon/consumers/request/constraint.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2021, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import { inject as service } from '@ember/service';

--- a/packages/reports/addon/consumers/request/filter.ts
+++ b/packages/reports/addon/consumers/request/filter.ts
@@ -7,8 +7,7 @@ import Route from '@ember/routing/route';
 import { setProperties } from '@ember/object';
 import ActionConsumer from 'navi-core/consumers/action-consumer';
 import RequestActionDispatcher, { RequestActions } from 'navi-reports/services/request-action-dispatcher';
-import { getSelectedMetricsOfBase, getUnfilteredMetricsOfBase ,
-} from 'navi-reports/utils/request-metric';
+import { getSelectedMetricsOfBase, getUnfilteredMetricsOfBase } from 'navi-reports/utils/request-metric';
 import MetricMetadataModel from 'navi-data/models/metadata/metric';
 import ColumnFragment from 'navi-core/models/bard-request-v2/fragments/column';
 import ReportModel from 'navi-core/models/report';
@@ -104,7 +103,7 @@ export default class FilterConsumer extends ActionConsumer {
 
       request.addFilter({
         ...filter,
-        ...(values ? { values } : {})
+        ...(values ? { values } : {}),
       });
     },
 

--- a/packages/reports/addon/consumers/request/filter.ts
+++ b/packages/reports/addon/consumers/request/filter.ts
@@ -7,10 +7,7 @@ import Route from '@ember/routing/route';
 import { setProperties } from '@ember/object';
 import ActionConsumer from 'navi-core/consumers/action-consumer';
 import RequestActionDispatcher, { RequestActions } from 'navi-reports/services/request-action-dispatcher';
-import {
-  getSelectedMetricsOfBase,
-  getFilteredMetricsOfBase,
-  getUnfilteredMetricsOfBase,
+import { getSelectedMetricsOfBase, getUnfilteredMetricsOfBase ,
 } from 'navi-reports/utils/request-metric';
 import MetricMetadataModel from 'navi-data/models/metadata/metric';
 import ColumnFragment from 'navi-core/models/bard-request-v2/fragments/column';
@@ -20,6 +17,8 @@ import { Parameters } from 'navi-data/adapters/facts/interface';
 import FilterFragment from 'navi-core/models/bard-request-v2/fragments/filter';
 import RequestFragment from 'navi-core/models/bard-request-v2/request';
 import TableMetadataModel from 'navi-data/models/metadata/table';
+import { OPERATORS, valuesForOperator } from 'navi-reports/components/filter-builders/time-dimension';
+import { Grain } from 'navi-data/utils/date';
 
 const DEFAULT_METRIC_FILTER: { operator: FilterFragment['operator']; values: FilterFragment['values'] } = {
   operator: 'gt',
@@ -53,51 +52,13 @@ export default class FilterConsumer extends ActionConsumer {
   }
 
   actions = {
-    [RequestActions.TOGGLE_FILTER](this: FilterConsumer, route: Route, column: ColumnFragment) {
-      const { canonicalName, columnMetadata, type, parameters } = column;
-      const { routeName } = route;
-      const { request } = route.modelFor(routeName) as ReportModel;
-      const filter = request.filters.find((filter) => filter.canonicalName === canonicalName);
+    [RequestActions.ADD_FILTER](this: FilterConsumer, route: Route, column: ColumnFragment) {
+      const { columnMetadata, type, parameters } = column;
 
-      //do not add filter if it already exists
-      if (!filter) {
-        switch (type) {
-          case 'metric':
-            this.requestActionDispatcher.dispatch(RequestActions.ADD_METRIC_FILTER, route, columnMetadata, parameters);
-            break;
-          case 'dimension':
-          case 'timeDimension':
-            this.requestActionDispatcher.dispatch(
-              RequestActions.ADD_DIMENSION_FILTER,
-              route,
-              columnMetadata,
-              parameters
-            );
-            break;
-        }
+      if (type === 'metric') {
+        this.requestActionDispatcher.dispatch(RequestActions.ADD_METRIC_FILTER, route, columnMetadata, parameters);
       } else {
-        //TODO fix me
-        this.requestActionDispatcher.dispatch(RequestActions.REMOVE_FILTER, route, column);
-      }
-    },
-
-    [RequestActions.TOGGLE_DIMENSION_FILTER](
-      this: FilterConsumer,
-      route: Route,
-      dimensionMetadataModel: DimensionMetadataModel
-    ) {
-      const { routeName } = route;
-      const { request } = route.modelFor(routeName) as ReportModel;
-      const filter = request.filters.find(
-        ({ type, columnMetadata }) =>
-          ['dimension', 'timeDimension'].includes(type) && columnMetadata === dimensionMetadataModel
-      );
-
-      //do not add filter if it already exists
-      if (!filter) {
-        this.requestActionDispatcher.dispatch(RequestActions.ADD_DIMENSION_FILTER, route, dimensionMetadataModel);
-      } else {
-        this.requestActionDispatcher.dispatch(RequestActions.REMOVE_FILTER, route, filter);
+        this.requestActionDispatcher.dispatch(RequestActions.ADD_DIMENSION_FILTER, route, columnMetadata, parameters);
       }
     },
 
@@ -118,7 +79,7 @@ export default class FilterConsumer extends ActionConsumer {
         type = type?.toLowerCase();
         const opDictionary: Record<string, FilterFragment['operator']> = {
           time: 'gte',
-          date: 'gte',
+          date: 'bet',
           number: 'eq',
           default: 'in',
         };
@@ -127,15 +88,23 @@ export default class FilterConsumer extends ActionConsumer {
       };
 
       const defaultOperator = findDefaultOperator(dimensionMetadataModel.valueType);
-
       const defaultParams = dimensionMetadataModel.getDefaultParameters() || {};
-      request.addFilter({
+      const filter = {
         type: dimensionMetadataModel.metadataType,
         source: dimensionMetadataModel.source,
         field: dimensionMetadataModel.id,
         parameters: { ...defaultParams, ...parameters },
         operator: defaultOperator,
         values: [],
+      };
+      let values;
+      if (dimensionMetadataModel.metadataType === 'timeDimension') {
+        values = valuesForOperator(filter, filter.parameters.grain as Grain, OPERATORS.lookback);
+      }
+
+      request.addFilter({
+        ...filter,
+        ...(values ? { values } : {})
       });
     },
 
@@ -157,38 +126,6 @@ export default class FilterConsumer extends ActionConsumer {
         parameters: { ...defaultParams, ...parameters },
         ...DEFAULT_METRIC_FILTER,
       });
-    },
-
-    /**
-     * @action TOGGLE_METRIC_FILTER
-     * @param route - route that has a model that contains a request property
-     * @param metricMetadataModel - metric to filter
-     */
-    [RequestActions.TOGGLE_METRIC_FILTER](
-      this: FilterConsumer,
-      route: Route,
-      metricMetadataModel: MetricMetadataModel
-    ) {
-      const { routeName } = route;
-      const { request } = route.modelFor(routeName) as ReportModel;
-
-      const metricFilters = getFilteredMetricsOfBase(metricMetadataModel, request);
-
-      const nextParameter = this._getNextParameterForMetric(metricMetadataModel, request);
-      const shouldAdd = !!nextParameter || !metricFilters.length;
-
-      if (shouldAdd) {
-        this.requestActionDispatcher.dispatch(
-          RequestActions.ADD_METRIC_FILTER,
-          route,
-          metricMetadataModel,
-          nextParameter
-        );
-      } else {
-        metricFilters.forEach((filter) => {
-          this.requestActionDispatcher.dispatch(RequestActions.REMOVE_FILTER, route, filter);
-        });
-      }
     },
 
     [RequestActions.UPDATE_FILTER](_route: Route, originalFilter: FilterFragment, changeSet: object) {

--- a/packages/reports/addon/routes/reports/report.js
+++ b/packages/reports/addon/routes/reports/report.js
@@ -32,6 +32,11 @@ export default Route.extend({
   updateReportActionDispatcher: service(),
 
   /**
+   * @property {Service} requestConstrainer
+   */
+  requestConstrainer: service(),
+
+  /**
    * @property {String} defaultVisualizationType - visualization type if not
    *                                               specified in report
    */
@@ -58,6 +63,8 @@ export default Route.extend({
    * @override
    */
   afterModel(report) {
+    this.requestConstrainer.constrain(this);
+
     if (get(report, 'isNew') && get(report, 'request.validations.isInvalid')) {
       return this.replaceWith(`${this.routeName}.edit`, get(report, 'tempId'));
     }

--- a/packages/reports/addon/services/request-action-dispatcher.ts
+++ b/packages/reports/addon/services/request-action-dispatcher.ts
@@ -12,9 +12,7 @@ export const RequestActions = <const>{
   RENAME_COLUMN_FRAGMENT: 'renameColumnFragment',
   REORDER_COLUMN_FRAGMENT: 'reorderColumnFragment',
 
-  TOGGLE_FILTER: 'toggleFilter',
-  TOGGLE_DIMENSION_FILTER: 'toggleDimensionFilter',
-  TOGGLE_METRIC_FILTER: 'toggleMetricFilter',
+  ADD_FILTER: 'addFilter',
   ADD_DIMENSION_FILTER: 'addDimensionFilter',
   ADD_METRIC_FILTER: 'addMetricFilter',
   UPDATE_FILTER: 'updateFilter',
@@ -29,6 +27,14 @@ export const RequestActions = <const>{
 
 export default class RequestActionDispatcher extends ActionDispatcher {
   get consumers() {
-    return [...super.consumers, 'request/column', 'request/filter', 'request/table', 'request/sort', 'request/fili'];
+    return [
+      ...super.consumers,
+      'request/column',
+      'request/filter',
+      'request/table',
+      'request/sort',
+      'request/fili',
+      'request/constraint'
+    ];
   }
 }

--- a/packages/reports/addon/services/request-action-dispatcher.ts
+++ b/packages/reports/addon/services/request-action-dispatcher.ts
@@ -34,7 +34,7 @@ export default class RequestActionDispatcher extends ActionDispatcher {
       'request/table',
       'request/sort',
       'request/fili',
-      'request/constraint'
+      'request/constraint',
     ];
   }
 }

--- a/packages/reports/addon/services/request-constrainer.ts
+++ b/packages/reports/addon/services/request-constrainer.ts
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2021, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+import Service, { inject as service } from '@ember/service';
+import { RequestActions } from './request-action-dispatcher';
+import { matches } from 'lodash-es';
+import type FragmentFactory from 'navi-core/services/fragment-factory';
+import type RequestFragment from 'navi-core/models/bard-request-v2/request';
+import type { RequestV2 } from 'navi-data/adapters/facts/interface';
+import type NaviMetadataService from 'navi-data/services/navi-metadata';
+import type Route from '@ember/routing/route';
+import type ReportModel from 'navi-core/models/report';
+import type UpdateReportActionDispatcher from './update-report-action-dispatcher';
+import type ColumnFragment from 'navi-core/models/bard-request-v2/fragments/column';
+import type FilterFragment from 'navi-core/models/bard-request-v2/fragments/filter';
+import type NaviNotificationService from 'navi-core/services/interfaces/navi-notifications';
+
+export type TemplateDispatcherAction = [string, ...any[]] & any[];
+
+type ConstrainedProperties = {
+  columns?: Set<ColumnFragment>;
+  filters?: Set<FilterFragment>;
+};
+
+export default class RequestConstrainer extends Service {
+  @service fragmentFactory!: FragmentFactory;
+  @service naviMetadata!: NaviMetadataService;
+  @service updateReportActionDispatcher!: UpdateReportActionDispatcher;
+  @service naviNotifications!: NaviNotificationService;
+
+  buildConstraints(request: RequestFragment): TemplateDispatcherAction[] {
+    if (!request.dataSource || !request.tableMetadata) {
+      return [];
+    }
+    const { tableMetadata } = request;
+
+    const serialized = request.serialize() as RequestV2;
+    return tableMetadata.requestConstraints
+      .filter(
+        (requestConstraint) => !requestConstraint.isSatisfied(serialized) && requestConstraint.type === 'existence'
+      )
+      .map(({ constraint }) => {
+        const { type, field } = constraint.matches;
+        const columnMetadata = this.naviMetadata.getById(type, field, request.dataSource);
+        if (constraint.property === 'filters') {
+          const columnFragment = this.fragmentFactory.createColumn(
+            type,
+            request.dataSource,
+            field,
+            columnMetadata?.getDefaultParameters()
+          );
+          return [RequestActions.ADD_FILTER, columnFragment];
+        } else {
+          return [RequestActions.ADD_COLUMN_WITH_PARAMS, columnMetadata];
+        }
+      });
+  }
+
+  constrain(route: Route): ReportModel {
+    const report = route.modelFor(route.routeName) as ReportModel;
+    const { request } = report;
+
+    const dispatcherActions = this.buildConstraints(request);
+    dispatcherActions.forEach((action) => {
+      const [actionName, ...args] = action;
+      this.updateReportActionDispatcher.dispatch(actionName, route, ...args);
+    });
+
+    const serialized = request.serialize() as RequestV2;
+    const unsatisfiedConstraints =
+      request.tableMetadata?.requestConstraints.filter((c) => !c.isSatisfied(serialized)) || [];
+    if (unsatisfiedConstraints.length > 0) {
+      this.naviNotifications.add({
+        title: `The following requirements are not satisfied`,
+        context: unsatisfiedConstraints.map((c) => c.description).join('; '),
+        style: 'warning',
+        timeout: 'none',
+      });
+    }
+
+    return report;
+  }
+
+  getConstrainedProperties(request: RequestFragment): ConstrainedProperties {
+    if (!request.dataSource || !request.tableMetadata) {
+      return {};
+    }
+    const { tableMetadata } = request;
+
+    return tableMetadata.requestConstraints.reduce((props: ConstrainedProperties, requestConstraint) => {
+      const { property, matches: partialProperties } = requestConstraint.constraint;
+      const func = matches(partialProperties);
+
+      //@ts-ignore
+      const matchingProp = request[property].find(func);
+
+      if (matchingProp) {
+        //@ts-ignore
+        props[property] = props[property] || new Set();
+        props[property]?.add(matchingProp);
+      }
+      return props;
+    }, {});
+  }
+}
+
+// DO NOT DELETE: this is how TypeScript knows how to look up your services.
+declare module '@ember/service' {
+  interface Registry {
+    'request-constrainer': RequestConstrainer;
+  }
+}

--- a/packages/reports/addon/services/request-constrainer.ts
+++ b/packages/reports/addon/services/request-constrainer.ts
@@ -73,7 +73,7 @@ export default class RequestConstrainer extends Service {
     if (unsatisfiedConstraints.length > 0) {
       this.naviNotifications.add({
         title: `The following requirements are not satisfied`,
-        context: unsatisfiedConstraints.map((c, idx) => `${idx}) ${c.description}`).join(' '),
+        context: unsatisfiedConstraints.map((c, idx) => `${idx + 1}) ${c.description}`).join(' '),
         style: 'warning',
         timeout: 'none',
       });

--- a/packages/reports/addon/services/request-constrainer.ts
+++ b/packages/reports/addon/services/request-constrainer.ts
@@ -73,7 +73,7 @@ export default class RequestConstrainer extends Service {
     if (unsatisfiedConstraints.length > 0) {
       this.naviNotifications.add({
         title: `The following requirements are not satisfied`,
-        context: unsatisfiedConstraints.map((c) => c.description).join('; '),
+        context: unsatisfiedConstraints.map((c, idx) => `${idx}) ${c.description}`).join(' '),
         style: 'warning',
         timeout: 'none',
       });

--- a/packages/reports/addon/templates/components/dimension-selector.hbs
+++ b/packages/reports/addon/templates/components/dimension-selector.hbs
@@ -35,10 +35,11 @@
       </NaviIcon>
 
       <div class="grouped-list__icon-set">
-        <NaviIcon
-          @icon="filter"
+        <DenaliIcon
+          @size="small"
+          @icon="filter-add"
           class={{concat (if (get-shallow this.dimensionsFiltered item.id) "grouped-list__filter--active ") "grouped-list__filter"}}
-          {{on "click" (fn this.onToggleDimFilter item)}}
+          {{on "click" (fn @onAddDimensionFilter item undefined)}}
         />
       </div>
     </div>

--- a/packages/reports/addon/templates/components/dimension-selector.hbs
+++ b/packages/reports/addon/templates/components/dimension-selector.hbs
@@ -38,7 +38,7 @@
         <DenaliIcon
           @size="small"
           @icon="filter-add"
-          class={{concat (if (get-shallow this.dimensionsFiltered item.id) "grouped-list__filter--active ") "grouped-list__filter"}}
+          class="{{if (get-shallow this.dimensionsFiltered item.id) "grouped-list__filter--active"}} grouped-list__filter"
           {{on "click" (fn @onAddDimensionFilter item undefined)}}
         />
       </div>

--- a/packages/reports/addon/templates/components/metric-selector.hbs
+++ b/packages/reports/addon/templates/components/metric-selector.hbs
@@ -37,19 +37,12 @@
 
         <div class="grouped-list__icon-set {{if (not (can-having metric)) "grouped-list__icon-set--no-filter"}}">
           {{#if (can-having metric)}}
-            <NaviIcon
-              @icon="filter"
+            <DenaliIcon
+              @icon="filter-add"
+              @size="small"
               class={{concat (if (get-shallow this.metricsFiltered metric.id) "grouped-list__filter--active ") "grouped-list__filter"}}
-              {{on "click" (fn @onToggleMetricFilter metric)}}
-            >
-              <EmberTooltip @side="right" @popperContainer="body" @effect="none">
-                {{#if (get-shallow this.metricsFiltered metric.id)}}
-                  Remove Filter
-                {{else}}
-                  Add Filter
-                {{/if}}
-              </EmberTooltip>
-            </NaviIcon>
+              {{on "click" (fn @onAddMetricFilter metric undefined)}}
+            />
           {{/if}}
         </div>
       </div>

--- a/packages/reports/addon/templates/components/metric-selector.hbs
+++ b/packages/reports/addon/templates/components/metric-selector.hbs
@@ -40,7 +40,7 @@
             <DenaliIcon
               @icon="filter-add"
               @size="small"
-              class={{concat (if (get-shallow this.metricsFiltered metric.id) "grouped-list__filter--active ") "grouped-list__filter"}}
+              class="{{if (get-shallow this.metricsFiltered metric.id) "grouped-list__filter--active"}} grouped-list__filter"
               {{on "click" (fn @onAddMetricFilter metric undefined)}}
             />
           {{/if}}

--- a/packages/reports/addon/templates/components/navi-column-config/item.hbs
+++ b/packages/reports/addon/templates/components/navi-column-config/item.hbs
@@ -11,7 +11,9 @@
       type="button"
       aria-label="delete {{dasherize @column.fragment.type}} {{@column.fragment.displayName}}"
       class="navi-column-config-item__remove-icon"
-      {{on "click" @onRemoveColumn}}>
+      disabled={{@column.isRequired}}
+      {{on "click" @onRemoveColumn}}
+    >
       <NaviIcon @icon="minus-circle" />
     </button>
 
@@ -34,7 +36,7 @@
     <NaviColumnConfig::Base
       @column={{@column}}
       @cloneColumn={{@cloneColumn}}
-      @toggleColumnFilter={{@toggleColumnFilter}}
+      @onAddFilter={{@onAddFilter}}
       @onRenameColumn={{@onRenameColumn}}
       @onUpdateColumnParam={{@onUpdateColumnParam}}
     />

--- a/packages/reports/addon/templates/components/navi-column-config/item.hbs
+++ b/packages/reports/addon/templates/components/navi-column-config/item.hbs
@@ -10,7 +10,7 @@
     <button
       type="button"
       aria-label="delete {{dasherize @column.fragment.type}} {{@column.fragment.displayName}}"
-      class="navi-column-config-item__remove-icon"
+      class="navi-column-config-item__remove-icon link"
       disabled={{@column.isRequired}}
       {{on "click" @onRemoveColumn}}
     >

--- a/packages/reports/addon/templates/components/report-builder.hbs
+++ b/packages/reports/addon/templates/components/report-builder.hbs
@@ -15,13 +15,13 @@
           class="report-builder__container report-builder__dimension-selector{{if @disabled " report-builder__container--disabled"}}"
           @request={{this.request}}
           @onAddDimension={{queue (fn (optional @onBeforeAddItem) this) (update-report-action "ADD_COLUMN_WITH_PARAMS")}}
-          @onToggleDimFilter={{queue (update-report-action "TOGGLE_DIMENSION_FILTER") this.onToggleDimFilter}}
+          @onAddDimensionFilter={{queue (update-report-action "ADD_DIMENSION_FILTER") this.onAddFilter}}
         />
         <MetricSelector
           class="report-builder__container report-builder__metric-selector{{if @disabled " report-builder__container--disabled"}}"
           @request={{this.request}}
           @onAddMetric={{queue (fn (optional @onBeforeAddItem) this) (update-report-action "ADD_COLUMN_WITH_PARAMS")}}
-          @onToggleMetricFilter={{queue (update-report-action "TOGGLE_METRIC_FILTER") this.onToggleMetricFilter}}
+          @onAddMetricFilter={{queue (update-report-action "ADD_METRIC_FILTER") this.onAddFilter}}
         />
       {{/if}}
     </div>

--- a/packages/reports/addon/templates/reports/report.hbs
+++ b/packages/reports/addon/templates/reports/report.hbs
@@ -61,7 +61,7 @@
         @openFilters={{route-action "openFilters"}}
         @onAddColumn={{update-report-action "ADD_COLUMN_WITH_PARAMS"}}
         @onRemoveColumn={{update-report-action "REMOVE_COLUMN_FRAGMENT"}}
-        @onToggleFilter={{update-report-action "TOGGLE_FILTER"}}
+        @onAddFilter={{update-report-action "ADD_FILTER"}}
         @onRenameColumn={{update-report-action "RENAME_COLUMN_FRAGMENT"}}
         @onReorderColumn={{update-report-action "REORDER_COLUMN_FRAGMENT"}}
         @onUpdateColumnParam={{update-report-action "UPDATE_COLUMN_FRAGMENT_WITH_PARAMS"}}

--- a/packages/reports/app/consumers/request/constraint.js
+++ b/packages/reports/app/consumers/request/constraint.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-reports/consumers/request/constraint';

--- a/packages/reports/app/services/request-constrainer.js
+++ b/packages/reports/app/services/request-constrainer.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-reports/services/request-constrainer';

--- a/packages/reports/app/styles/navi-reports/components/navi-column-config.less
+++ b/packages/reports/app/styles/navi-reports/components/navi-column-config.less
@@ -8,7 +8,7 @@
   cursor: pointer;
 
   &--active,
-  &:hover {
+  &:hover:not(:disabled) {
     color: @denali-link-hover;
   }
 

--- a/packages/reports/app/styles/navi-reports/components/navi-column-config/item.less
+++ b/packages/reports/app/styles/navi-reports/components/navi-column-config/item.less
@@ -106,6 +106,11 @@
     padding: 0;
     width: 14px;
     text-align: center;
+
+    &:disabled {
+      color: @denali-grey-500;
+      cursor: not-allowed;
+    }
   }
 
   &--open {

--- a/packages/reports/app/styles/navi-reports/components/navi-column-config/item.less
+++ b/packages/reports/app/styles/navi-reports/components/navi-column-config/item.less
@@ -106,11 +106,6 @@
     padding: 0;
     width: 14px;
     text-align: center;
-
-    &:disabled {
-      color: @denali-grey-500;
-      cursor: not-allowed;
-    }
   }
 
   &--open {

--- a/packages/reports/tests/acceptance/column-config-test.js
+++ b/packages/reports/tests/acceptance/column-config-test.js
@@ -362,7 +362,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
       .doesNotExist('No column is highlighted after removing the parameterized metric');
   });
 
-  test('clicking filter button always adds a new filter', async function(assert) {
+  test('clicking filter button always adds a new filter', async function (assert) {
     assert.expect(3);
     await visit('/reports/new');
 

--- a/packages/reports/tests/acceptance/column-config-test.js
+++ b/packages/reports/tests/acceptance/column-config-test.js
@@ -362,6 +362,20 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
       .doesNotExist('No column is highlighted after removing the parameterized metric');
   });
 
+  test('clicking filter button always adds a new filter', async function(assert) {
+    assert.expect(3);
+    await visit('/reports/new');
+
+    assert.dom('.filter-builder__subject').exists({ count: 1 }, 'There is 1 filter to start');
+    await clickItem('dimension', 'Age');
+
+    await click('.navi-column-config-base__filter-icon');
+    assert.dom('.filter-builder__subject').exists({ count: 2 }, 'Clicking the filter button adds a new filter');
+
+    await click('.navi-column-config-base__filter-icon');
+    assert.dom('.filter-builder__subject').exists({ count: 3 }, 'Clicking the filter button again adds a new filter');
+  });
+
   skip('adding, removing and changing - date time', async function (assert) {
     //TODO update when filter updates are complete
     assert.expect(7);

--- a/packages/reports/tests/acceptance/column-config-test.js
+++ b/packages/reports/tests/acceptance/column-config-test.js
@@ -376,37 +376,38 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
     assert.dom('.filter-builder__subject').exists({ count: 3 }, 'Clicking the filter button again adds a new filter');
   });
 
-  skip('adding, removing and changing - date time', async function (assert) {
-    //TODO update when filter updates are complete
+  test('adding, removing and changing - date time', async function (assert) {
     assert.expect(7);
     await visit('reports/1/edit');
 
-    assert.dom('.filter-builder__subject').hasText('Date Time (Day)', 'Time grain is initially day');
+    assert.dom('.filter-builder__subject').hasText('Date Time (day)', 'Time grain is initially day');
 
-    await click('.navi-column-config-item__remove-icon'); // Remove Date Time (Day)
+    await click('.navi-column-config-item__remove-icon'); // Remove Date Time (day)
 
-    assert.dom('.filter-builder__subject').hasText('Date Time (All)', 'Deselecting day changes time grain to all');
+    assert.dom('.filter-builder__subject').hasText('Date Time (hour)', 'Deselecting day changes time grain to hour');
     await animationsSettled();
-    assert.deepEqual(getColumns(), ['Property', 'Ad Clicks', 'Nav Link Clicks'], 'Date Time is removed');
+    assert.deepEqual(getColumns(), ['Property (id)', 'Ad Clicks', 'Nav Link Clicks'], 'Date Time is removed');
 
     await clickItem('dimension', 'Date Time');
     await animationsSettled();
 
-    assert.dom('.filter-builder__subject').hasText('Date Time (Day)', 'Default time grain (day) is set on the report');
+    assert
+      .dom('.filter-builder__subject')
+      .hasText('Date Time (hour)', 'Date time matches existing filter grain on the report');
     assert.deepEqual(
       getColumns(),
-      ['Date Time (Day)', 'Property', 'Ad Clicks', 'Nav Link Clicks'],
-      'A Date Time (Day) column is added'
+      ['Property (id)', 'Ad Clicks', 'Nav Link Clicks', 'Date Time (hour)'],
+      'A Date Time (hour) column is added'
     );
     await selectChoose('.navi-column-config-item__parameter-trigger', 'Week');
 
     assert
       .dom('.filter-builder__subject')
-      .hasText('Date Time (Week)', 'Choosing week changes timegrain from day to week');
+      .hasText('Date Time (isoWeek)', 'Choosing week changes timegrain from day to week');
     assert.deepEqual(
       getColumns(),
-      ['Date Time (Week)', 'Property', 'Ad Clicks', 'Nav Link Clicks'],
-      'Column is changed to Date Time (Week)'
+      ['Property (id)', 'Ad Clicks', 'Nav Link Clicks', 'Date Time (isoWeek)'],
+      'Column is changed to Date Time (isoWeek)'
     );
   });
 

--- a/packages/reports/tests/acceptance/fili-datasource-test.ts
+++ b/packages/reports/tests/acceptance/fili-datasource-test.ts
@@ -1,19 +1,24 @@
-import { click, visit } from '@ember/test-helpers';
-//@ts-expect-error
-import { clickTrigger } from 'ember-basic-dropdown/test-support/helpers';
-//@ts-expect-error
-import { setupMirage } from 'ember-cli-mirage/test-support';
-//@ts-expect-error
-import { selectChoose } from 'ember-power-select/test-support';
-import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
+import { click, visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+//@ts-ignore
+import { setupAnimationTest } from 'ember-animated/test-support';
+//@ts-ignore
+import { clickTrigger } from 'ember-basic-dropdown/test-support/helpers';
+//@ts-ignore
+import { setupMirage } from 'ember-cli-mirage/test-support';
+//@ts-ignore
+import { selectChoose } from 'ember-power-select/test-support';
+//@ts-ignore
+import { clickItem } from 'navi-reports/test-support/report-builder';
 import { capitalize } from '@ember/string';
 
-module('Acceptance | date filter', function (hooks) {
+module('Acceptance | fili datasource', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupAnimationTest(hooks);
 
-  test('verify the different time grains work as expected - bard', async function (assert) {
+  test('verify the different time grains work as expected - fili', async function (assert) {
     assert.expect(78);
 
     await visit('/reports/13/view');
@@ -73,5 +78,52 @@ module('Acceptance | date filter', function (hooks) {
       await clickTrigger('.filter-values--date-input__trigger .ember-basic-dropdown-trigger');
       assert.dom('.ember-power-calendar').exists('Calendar opened');
     }
+  });
+
+  test('Fili Required filters on new report', async function(assert) {
+    assert.expect(5);
+
+    await visit('/reports/new');
+
+    await selectChoose('.navi-table-select__trigger', 'Network');
+    assert.dom('.navi-table-select-item').hasText('Network', 'A fili table is selected');
+
+    assert.dom('.filter-builder__subject').hasText('Date Time (day)', 'A date time filter exists on a new report');
+    assert.dom('.filter-collection__remove').isDisabled('The date time filter cannot be removed');
+
+    await clickItem('dimension', 'Date Time');
+    assert.dom('.navi-column-config-item__name').hasText('Date Time (day)', 'The date time column was added');
+    assert
+      .dom('.navi-column-config-item__remove-icon')
+      .isNotDisabled('The date time can be removed when there is an all grain');
+  });
+
+  test('Fili Required filters when changing table', async function(assert) {
+    assert.expect(2);
+
+    await visit('/reports/new');
+    await selectChoose('.navi-table-select__trigger', 'Table A');
+
+    assert
+      .dom('.filter-builder__subject')
+      .hasText('Date Time (day)', 'A date time filter exists after switching tables');
+    assert.dom('.filter-collection__remove').isDisabled('The date time filter cannot be removed');
+  });
+
+  test('Fili Required filters when changing table without all grain', async function(assert) {
+    assert.expect(4);
+
+    await visit('/reports/new');
+    await selectChoose('.navi-table-select__trigger', 'Table C');
+
+    assert
+      .dom('.filter-builder__subject')
+      .hasText('Date Time (day)', 'A date time filter exists after switching tables');
+    assert.dom('.filter-collection__remove').isDisabled('The date time filter cannot be removed');
+
+    assert
+      .dom('.navi-column-config-item__name')
+      .hasText('Date Time (day)', 'A date time column exists after switching to a table with no all grain');
+    assert.dom('.navi-column-config-item__remove-icon').isDisabled('The date time column cannot be removed');
   });
 });

--- a/packages/reports/tests/acceptance/fili-datasource-test.ts
+++ b/packages/reports/tests/acceptance/fili-datasource-test.ts
@@ -80,7 +80,7 @@ module('Acceptance | fili datasource', function (hooks) {
     }
   });
 
-  test('Fili Required filters on new report', async function(assert) {
+  test('Fili Required filters on new report', async function (assert) {
     assert.expect(5);
 
     await visit('/reports/new');
@@ -98,7 +98,7 @@ module('Acceptance | fili datasource', function (hooks) {
       .isNotDisabled('The date time can be removed when there is an all grain');
   });
 
-  test('Fili Required filters when changing table', async function(assert) {
+  test('Fili Required filters when changing table', async function (assert) {
     assert.expect(2);
 
     await visit('/reports/new');
@@ -110,7 +110,7 @@ module('Acceptance | fili datasource', function (hooks) {
     assert.dom('.filter-collection__remove').isDisabled('The date time filter cannot be removed');
   });
 
-  test('Fili Required filters when changing table without all grain', async function(assert) {
+  test('Fili Required filters when changing table without all grain', async function (assert) {
     assert.expect(4);
 
     await visit('/reports/new');

--- a/packages/reports/tests/acceptance/multi-datasource-test.js
+++ b/packages/reports/tests/acceptance/multi-datasource-test.js
@@ -20,7 +20,7 @@ module('Acceptance | multi-datasource report builder', function (hooks) {
   });
 
   test('multi datasource report', async function (assert) {
-    assert.expect(14);
+    assert.expect(15);
 
     config.navi.FEATURES.exportFileTypes = ['csv', 'pdf', 'png'];
 
@@ -44,9 +44,8 @@ module('Acceptance | multi-datasource report builder', function (hooks) {
     await fillIn('input.filter-values--value-input', '1');
 
     await clickItem('dimension', 'Date Time');
-    await clickItemFilter('dimension', 'Date Time');
 
-    await selectChoose($('.filter-builder__operator-trigger:eq(1)')[0], 'Between');
+    await selectChoose($('.filter-builder__operator-trigger:eq(0)')[0], 'Between');
     await clickTrigger('.filter-values--date-range-input__low-value .ember-basic-dropdown-trigger');
     await click($('button.ember-power-calendar-day--current-month:contains(4)')[0]);
     await clickTrigger('.filter-values--date-range-input__high-value .ember-basic-dropdown-trigger');
@@ -57,7 +56,7 @@ module('Acceptance | multi-datasource report builder', function (hooks) {
     //Check if filters meta data is displaying properly
     assert.deepEqual(
       findAll('.filter-builder__subject, .filter-builder__subject').map((el) => el.textContent.trim()),
-      ['Container (id)', 'Date Time (day)', 'Used Amount'],
+      ['Date Time (day)', 'Container (id)', 'Used Amount'],
       'Filter titles rendered correctly'
     );
 
@@ -69,11 +68,14 @@ module('Acceptance | multi-datasource report builder', function (hooks) {
     await click('.report-builder__container-header__filters-toggle');
     assert
       .dom('.report-builder__container--filters--collapsed')
-      .containsText('Filters Container (id) equals 1 Date Time (day) between', 'Collapsed filter contains right text');
+      .containsText('Filters Date Time (day) between', 'Collapsed date filter contains right text');
+    assert
+      .dom('.report-builder__container--filters--collapsed')
+      .containsText('Container (id) equals 1', 'Collapsed dimension filter contains right text');
 
     assert
       .dom('.report-builder__container--filters--collapsed')
-      .containsText('Used Amount greater than (>) 1', 'Collapsed filter contains right text');
+      .containsText('Used Amount greater than (>) 1', 'Collapsed metric filter contains right text');
     //check visualizations are showing up correctly
     assert.deepEqual(
       findAll('.table-widget__table-headers .table-header-cell__title').map((el) => el.textContent.trim()),
@@ -176,7 +178,7 @@ module('Acceptance | multi-datasource report builder', function (hooks) {
     //assert filters, metrics and dimensions are reset
     assert
       .dom('.report-builder__container--filters--collapsed')
-      .doesNotIncludeText('Date Time (day)', 'Filters do not include dimension filters from external table');
+      .includesText('Date Time (day)', 'The request is constrained and adds back the required filters');
 
     assert.deepEqual(await getAllSelected('dimension'), [], 'All dimensions are removed when table is changed');
     assert.deepEqual(await getAllSelected('metric'), [], 'All metrics are removed when table is changed');

--- a/packages/reports/tests/acceptance/report-test.js
+++ b/packages/reports/tests/acceptance/report-test.js
@@ -104,7 +104,6 @@ module('Acceptance | Navi Report', function (hooks) {
 
     /* == Add filter == */
     await clickItemFilter('dimension', 'Operating System');
-    await clickItemFilter('dimension', 'Date Time');
 
     /* == Run with errors == */
     await click('.navi-report__run-btn');
@@ -149,7 +148,6 @@ module('Acceptance | Navi Report', function (hooks) {
 
     //add date-dimension
     await clickItem('dimension', 'Date Time');
-    await clickItemFilter('dimension', 'Date Time');
 
     //set the filter interval
     await selectChoose('.filter-builder__operator-trigger', 'Between');
@@ -241,7 +239,6 @@ module('Acceptance | Navi Report', function (hooks) {
     await visit('/reports');
     await visit('/reports/new');
 
-    await clickItemFilter('dimension', 'Date Time');
     await clickItem('dimension', 'Date Time');
     await selectChoose('.navi-column-config-item__parameter-trigger', 'Day');
     await selectChoose('.filter-builder__operator-trigger', 'Between');
@@ -302,7 +299,6 @@ module('Acceptance | Navi Report', function (hooks) {
 
     //Add a metrics and save the report
     await clickItem('dimension', 'Date Time');
-    await clickItemFilter('dimension', 'Date Time');
     await selectChoose('.filter-builder__operator-trigger', 'Between');
     await clickItem('metric', 'Additive Page Views');
     await click('.navi-report__save-btn');
@@ -484,8 +480,6 @@ module('Acceptance | Navi Report', function (hooks) {
     // Build a report
     await clickItem('metric', 'Ad Clicks');
     await clickItem('dimension', 'Date Time');
-    await clickItemFilter('dimension', 'Date Time');
-    await selectChoose('.filter-builder__operator-trigger', 'In The Past');
     await click('.navi-report__run-btn');
 
     assert.ok(TempIdRegex.test(currentURL()), 'Creating a report brings user to /view route with a temp id');
@@ -1107,7 +1101,6 @@ module('Acceptance | Navi Report', function (hooks) {
     await clickItem('metric', 'Ad Clicks');
     await clickItem('dimension', 'Date Time');
     await selectChoose('.navi-column-config-item__parameter-trigger', 'Day');
-    await clickItemFilter('dimension', 'Date Time');
     await selectChoose('.filter-builder__operator-trigger', 'In The Past');
 
     await click('.navi-report__run-btn');
@@ -1455,37 +1448,44 @@ module('Acceptance | Navi Report', function (hooks) {
       .isVisible("Dimension select is used when the dimension's storage strategy is not 'none'");
   });
 
-  test('filter - add and remove using filter icon', async function (assert) {
+  test('filter - add using filter icon', async function (assert) {
     assert.expect(4);
 
     await visit('/reports/1');
     //add dimension filter
     await clickItemFilter('dimension', 'Operating System');
 
-    assert.ok(
-      !!$('.filter-builder__subject:contains(Operating System)'.length),
+    assert.strictEqual(
+      $('.filter-builder__subject:contains(Operating System)').length,
+      1,
       'The Operating System dimension filter is added'
     );
 
     //remove filter by clicking on filter icon again
     await clickItemFilter('dimension', 'Operating System');
 
-    assert.notOk(
-      !!$('.filter-builder__subject:contains(Operating System)').length,
-      'The Operating System dimension filter is removed when filter icon is clicked again'
+    assert.strictEqual(
+      $('.filter-builder__subject:contains(Operating System)').length,
+      2,
+      'The Operating System dimension filter is added a second time'
     );
 
     //add metric filter
     await clickItemFilter('metric', 'Ad Clicks');
 
-    assert.ok(!!$('.filter-builder__subject:contains(Ad Clicks)').length, 'The Ad Clicks metric filter is added');
+    assert.strictEqual(
+      $('.filter-builder__subject:contains(Ad Clicks)').length,
+      1,
+      'The Ad Clicks metric filter is added'
+    );
 
     //remove metric filter by clicking on filter icon again
     await clickItemFilter('metric', 'Ad Clicks');
 
-    assert.notOk(
-      !!$('.filter-builder__subject:contains(Ad Clicks)').length,
-      'The Ad Clicks metric filter is removed when filter icon is clicked again'
+    assert.strictEqual(
+      $('.filter-builder__subject:contains(Ad Clicks)').length,
+      2,
+      'The Ad Clicks metric filter is added a second time'
     );
   });
 
@@ -1846,7 +1846,6 @@ module('Acceptance | Navi Report', function (hooks) {
     await clickItem('dimension', 'EventId');
     await clickItem('metric', 'Network Sessions');
     await clickItem('dimension', 'Date Time');
-    await clickItemFilter('dimension', 'Date Time');
     await selectChoose('.filter-builder__operator-trigger', 'Between');
 
     await clickTrigger('.filter-values--date-range-input__low-value');
@@ -1887,10 +1886,9 @@ module('Acceptance | Navi Report', function (hooks) {
     await selectChoose('.filter-values--dimension-select__trigger', 'no');
     await selectChoose('.filter-values--dimension-select__trigger', 'yes');
 
-    await clickItemFilter('dimension', 'Date Time');
     await clickItem('dimension', 'Date Time');
 
-    await selectChoose(findAll('.filter-builder__operator-trigger')[1], 'Between');
+    await selectChoose('.filter-builder__operator-trigger', 'Between');
 
     await clickTrigger('.filter-values--date-range-input__low-value');
 

--- a/packages/reports/tests/acceptance/report-view-overlay-test.ts
+++ b/packages/reports/tests/acceptance/report-view-overlay-test.ts
@@ -57,11 +57,11 @@ module('Acceptance | report-view-overlay', function (hooks) {
     assert.expect(4);
 
     await visit('/reports/1/view');
-    await clickItem('metric', 'Nav Link Clicks', undefined);
+    await clickItem('metric', 'Nav Link Clicks');
     assertOverlayNotVisible(assert, 'The overlay is not visible when a duplicate column is added');
     await click('[aria-label="delete metric Nav Link Clicks"]');
     assertOverlayNotVisible(assert, 'The overlay is not visible when a duplicate column is removed');
-    await clickItem('metric', 'Revenue', undefined);
+    await clickItem('metric', 'Revenue');
     assertOverlayVisible(assert, 'The overlay is visible when a new column is added');
     await clickRevertReport();
     assertOverlayNotVisible(assert);
@@ -71,12 +71,12 @@ module('Acceptance | report-view-overlay', function (hooks) {
     assert.expect(5);
 
     await visit('/reports/1/view');
-    await clickItem('metric', 'Revenue', undefined);
+    await clickItem('metric', 'Revenue');
     assertOverlayVisible(assert, 'The overlay is visible when a new column is added');
     await clickOverlayDismiss();
     assertOverlayNotVisible(assert, 'The overlay is not visible after being dismissed');
     assertReportNeedsRun(assert, 'Dismissing the overlay does not update the report');
-    await clickItem('dimension', 'Age', undefined);
+    await clickItem('dimension', 'Age');
     assertOverlayNotVisible(assert, 'The overlay is not visible when new updates are made');
     assertReportNeedsRun(assert, 'The report still needs to be run');
   });

--- a/packages/reports/tests/integration/components/dimension-selector-test.js
+++ b/packages/reports/tests/integration/components/dimension-selector-test.js
@@ -13,7 +13,7 @@ let Store, MetadataService, Age;
 const TEMPLATE = hbs`<DimensionSelector
   @request={{this.request}}
   @onAddDimension={{this.onAddDimension}}
-  @onToggleDimFilter={{this.onToggleDimFilter}}
+  @onAddDimensionFilter={{this.onAddDimensionFilter}}
 />`;
 
 module('Integration | Component | dimension selector', function (hooks) {
@@ -25,7 +25,7 @@ module('Integration | Component | dimension selector', function (hooks) {
     MetadataService = this.owner.lookup('service:navi-metadata');
 
     this.set('onAddDimension', () => {});
-    this.set('onToggleDimFilter', () => {});
+    this.set('onAddDimensionFilter', () => {});
 
     await MetadataService.loadMetadata();
     Age = MetadataService.getById('dimension', 'age', 'bardOne');
@@ -88,7 +88,7 @@ module('Integration | Component | dimension selector', function (hooks) {
     //addDimension when an unselected dimension is clicked
     await clickItem('dimension', 'Gender');
 
-    //clicking again adds when feature flag is on
+    //clicking again adds again
     await clickItem('dimension', 'Gender');
   });
 
@@ -112,7 +112,7 @@ module('Integration | Component | dimension selector', function (hooks) {
       );
     await resetGender();
 
-    this.set('onToggleDimFilter', (dimension) => {
+    this.set('onAddDimensionFilter', (dimension) => {
       assert.deepEqual(dimension, Age, 'The age dimension is passed to the action when filter icon is clicked');
     });
 

--- a/packages/reports/tests/integration/components/metric-selector-test.js
+++ b/packages/reports/tests/integration/components/metric-selector-test.js
@@ -15,7 +15,7 @@ let Store, MetadataService, AdClicks;
 const TEMPLATE = hbs`<MetricSelector
   @request={{this.request}}
   @onAddMetric={{this.onAddMetric}}
-  @onToggleMetricFilter={{this.onToggleMetricFilter}}
+  @onAddMetricFilter={{this.onAddMetricFilter}}
 />`;
 
 module('Integration | Component | metric selector', function (hooks) {
@@ -40,7 +40,7 @@ module('Integration | Component | metric selector', function (hooks) {
     );
 
     this.set('onAddMetric', () => {});
-    this.set('onToggleMetricFilter', () => {});
+    this.set('onAddMetricFilter', () => {});
 
     await MetadataService.loadMetadata();
     AdClicks = MetadataService.getById('metric', 'adClicks', 'bardOne');
@@ -106,7 +106,7 @@ module('Integration | Component | metric selector', function (hooks) {
     );
     await totalClicksReset();
 
-    this.set('onToggleMetricFilter', (metric) => {
+    this.set('onAddMetricFilter', (metric) => {
       assert.deepEqual(metric, AdClicks, 'The adclicks metric is passed to the action when filter icon is clicked');
     });
 

--- a/packages/reports/tests/integration/components/navi-column-config-test.js
+++ b/packages/reports/tests/integration/components/navi-column-config-test.js
@@ -22,7 +22,7 @@ const TEMPLATE = hbs`
   @report={{this.report}}
   @onAddColumn={{optional this.onAddColumn}}
   @onRemoveColumn={{optional this.onRemoveColumn}}
-  @onToggleFilter={{optional this.onToggleFilter}}
+  @onAddFilter={{optional this.onAddFilter}}
   @openFilters={{optional this.openFilters}}
   @onRenameColumn={{optional this.onRenameColumn}}
   @onReorderColumn={{optional this.onReorderColumn}}
@@ -334,7 +334,7 @@ module('Integration | Component | navi-column-config', function (hooks) {
 
     this.onAddColumn = () => assert.ok(true, 'onAddColumn was called for time dimension column');
     this.onRemoveColumn = () => assert.ok(true, 'onRemoveColumn was called for time dimension column');
-    this.onToggleFilter = () => assert.ok(true, 'onToggleFilter was called for time dimension column');
+    this.onAddFilter = () => assert.ok(true, 'onAddFilter was called for time dimension column');
 
     addItem('timeDimension', 'tableA.dateTime', 'bardOne', { grain: 'day' });
     await render(TEMPLATE);
@@ -358,7 +358,7 @@ module('Integration | Component | navi-column-config', function (hooks) {
     assert.expect(8);
 
     this.onAddColumn = () => assert.ok(true, 'Clone was called');
-    this.onToggleFilter = () => assert.ok(true, 'Filter was called');
+    this.onAddFilter = () => assert.ok(true, 'Filter was called');
     this.onRemoveColumn = () => assert.ok(true, 'onRemoveColumn was called');
     addItem('metric', 'navClicks', 'bardOne');
     await render(TEMPLATE);
@@ -396,7 +396,7 @@ module('Integration | Component | navi-column-config', function (hooks) {
     assert.expect(8);
 
     this.onAddColumn = () => assert.ok(true, 'Clone was called');
-    this.onToggleFilter = () => assert.ok(true, 'Filter was called');
+    this.onAddFilter = () => assert.ok(true, 'Filter was called');
     this.onRemoveColumn = () => assert.ok(true, 'onRemoveColumn was called');
     addItem('dimension', 'browser', 'bardOne');
 

--- a/packages/reports/tests/integration/components/navi-column-config-test.js
+++ b/packages/reports/tests/integration/components/navi-column-config-test.js
@@ -355,7 +355,7 @@ module('Integration | Component | navi-column-config', function (hooks) {
   });
 
   test('Header config buttons - metric', async function (assert) {
-    assert.expect(8);
+    assert.expect(5);
 
     this.onAddColumn = () => assert.ok(true, 'Clone was called');
     this.onAddFilter = () => assert.ok(true, 'Filter was called');
@@ -376,24 +376,10 @@ module('Integration | Component | navi-column-config', function (hooks) {
     await click('.navi-column-config-base__clone-icon');
     assert.dom('.navi-column-config-base__filter-icon').exists({ count: 1 }, 'Metric config has filter icon');
     await click('.navi-column-config-base__filter-icon');
-
-    assert
-      .dom('.navi-column-config-base__filter-icon')
-      .doesNotHaveClass('navi-column-config-base__filter-icon--active', 'Metric config filter is not active');
-
-    const { request } = this.report;
-    request.addFilter({ ...request.columns.objectAt(0).serialize(), operator: 'in', values: [] });
-    await settled();
-    assert
-      .dom('.navi-column-config-base__filter-icon')
-      .hasClass('navi-column-config-base__filter-icon--active', 'Metric config filter is active if there is a having');
-
-    await click(findAll('.navi-column-config-item__remove-icon')[0]);
-    await animationsSettled();
   });
 
   test('Header config buttons - dimension', async function (assert) {
-    assert.expect(8);
+    assert.expect(5);
 
     this.onAddColumn = () => assert.ok(true, 'Clone was called');
     this.onAddFilter = () => assert.ok(true, 'Filter was called');
@@ -414,24 +400,6 @@ module('Integration | Component | navi-column-config', function (hooks) {
     await click('.navi-column-config-base__clone-icon');
     assert.dom('.navi-column-config-base__filter-icon').exists({ count: 1 }, 'Dimension config has filter icon');
     await click('.navi-column-config-base__filter-icon');
-
-    assert
-      .dom('.navi-column-config-base__filter-icon')
-      .doesNotHaveClass('navi-column-config-base__filter-icon--active', 'Dimension config filter is not active');
-
-    const { request } = this.report;
-    request.addFilter({ ...request.columns.objectAt(0).serialize(), operator: 'in', values: [] });
-    await settled();
-
-    assert
-      .dom('.navi-column-config-base__filter-icon')
-      .hasClass(
-        'navi-column-config-base__filter-icon--active',
-        'Dimension config filter is active if there is a filter'
-      );
-
-    await click(findAll('.navi-column-config-item__remove-icon')[0]);
-    await animationsSettled();
   });
 
   test('last added column', async function (assert) {

--- a/packages/reports/tests/integration/components/navi-column-config-test.js
+++ b/packages/reports/tests/integration/components/navi-column-config-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, findAll, click, settled } from '@ember/test-helpers';
+import { render, findAll, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupAnimationTest, animationsSettled } from 'ember-animated/test-support';

--- a/packages/reports/tests/integration/components/navi-column-config/base-test.js
+++ b/packages/reports/tests/integration/components/navi-column-config/base-test.js
@@ -6,9 +6,9 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 const TEMPLATE = hbs`
 <NaviColumnConfig::Base
-  @column={{this.column}} 
+  @column={{this.column}}
   @cloneColumn={{optional this.cloneColumn}}
-  @toggleColumnFilter={{optional this.toggleColumnFilter}}
+  @onAddFilter={{optional this.onAddFilter}}
   @onRenameColumn={{optional this.onRenameColumn}}
   @onUpdateColumnParam={{optional this.onUpdateColumnParam}}
 />`;
@@ -69,7 +69,7 @@ module('Integration | Component | navi-column-config/base', function (hooks) {
       fragment: this.fragmentFactory.createColumn('dimension', 'bardOne', 'property'),
     };
     this.cloneColumn = () => assert.ok(true, 'cloneColumn is called when clone is clicked');
-    this.toggleColumnFilter = () => assert.ok(true, 'toggleColumnFilter is called when filter is clicked');
+    this.onAddFilter = () => assert.ok(true, 'onAddFilter is called when filter is clicked');
     this.onUpdateColumnName = (newName) =>
       assert.equal(newName, 'Some other value', 'onUpdateColumnName action is called with new column name');
 

--- a/packages/reports/tests/integration/components/navi-column-config/base-test.js
+++ b/packages/reports/tests/integration/components/navi-column-config/base-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click } from '@ember/test-helpers';
+import { render, click, triggerKeyEvent, fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
@@ -64,51 +64,25 @@ module('Integration | Component | navi-column-config/base', function (hooks) {
   });
 
   test('it supports action', async function (assert) {
-    assert.expect(2);
+    assert.expect(4);
     this.column = {
       fragment: this.fragmentFactory.createColumn('dimension', 'bardOne', 'property'),
     };
     this.cloneColumn = () => assert.ok(true, 'cloneColumn is called when clone is clicked');
     this.onAddFilter = () => assert.ok(true, 'onAddFilter is called when filter is clicked');
-    this.onUpdateColumnName = (newName) =>
-      assert.equal(newName, 'Some other value', 'onUpdateColumnName action is called with new column name');
+    this.onRenameColumn = (newName) =>
+      assert.equal(newName, 'Some other value', 'onRenameColumn action is called with new column name');
 
     await render(TEMPLATE);
 
-    /**
-     * TODO: Uncomment when Column Renaming is enabled
-     * assert
-     *   .dom('input.navi-column-config-base__column-name-input')
-     *   .hasValue('Property', "Column Name field has value of column's display name");
-     * await fillIn('input.navi-column-config-base__column-name-input', 'Some other value');
-     * await triggerKeyEvent('input.navi-column-config-base__column-name-input', 'keyup', 13);
-     */
+    const columnNameInput = '.navi-column-config-base__column-name input';
+    assert
+      .dom(columnNameInput)
+      .hasProperty('placeholder', 'Property', "Column Name field has placeholder of column's display name");
+    await fillIn(columnNameInput, 'Some other value');
+    await triggerKeyEvent(columnNameInput, 'keyup', 13);
 
     await click('.navi-column-config-base__clone-icon');
     await click('.navi-column-config-base__filter-icon');
-  });
-
-  test('Filter is active when column is filtered', async function (assert) {
-    assert.expect(2);
-
-    this.column = {
-      isFiltered: false,
-      fragment: this.fragmentFactory.createColumn('dimension', 'bardOne', 'property'),
-    };
-
-    await render(TEMPLATE);
-
-    assert
-      .dom('.navi-column-config-base__filter-icon')
-      .doesNotHaveClass('navi-column-config-base__filter-icon--active', 'The filter is not active by default');
-
-    this.set('column', {
-      ...this.column,
-      isFiltered: true,
-    });
-
-    assert
-      .dom('.navi-column-config-base__filter-icon')
-      .hasClass('navi-column-config-base__filter-icon--active', 'The filter is active when the column is filtered');
   });
 });

--- a/packages/reports/tests/integration/components/navi-column-config/metric-test.js
+++ b/packages/reports/tests/integration/components/navi-column-config/metric-test.js
@@ -12,7 +12,7 @@ const TEMPLATE = hbs`
 <NaviColumnConfig::Base
   @column={{this.column}}
   @cloneColumn={{optional this.cloneColumn}}
-  @toggleColumnFilter={{optional this.toggleColumnFilter}}
+  @onAddFilter={{optional this.onAddFilter}}
   @onRenameColumn={{optional this.onRenameColumn}}
   @onUpdateColumnParam={{this.onUpdateColumnParam}}
 />

--- a/packages/reports/tests/integration/components/navi-column-config/metric-test.js
+++ b/packages/reports/tests/integration/components/navi-column-config/metric-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click, findAll, getContext, triggerEvent } from '@ember/test-helpers';
+import { render, click, findAll, getContext, triggerEvent, triggerKeyEvent, fillIn } from '@ember/test-helpers';
 import { selectChoose } from 'ember-power-select/test-support/helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -127,15 +127,12 @@ module('Integration | Component | navi-column-config/metric', function (hooks) {
   });
 
   test('Configuring metric column', async function (assert) {
-    assert.expect(4);
+    assert.expect(7);
 
     this.column = await getMetricColumn('revenue', { currency: 'USD' });
-    this.onRenameColumn = (/*newName*/) => {
+    this.onRenameColumn = (newName) => {
       // this must be called with action in the template
-      /**
-       * TODO: Reenable column relabeling, uncomment line below
-       */
-      // assert.equal(newName, 'Money', 'New display name is passed to name update action');
+      assert.equal(newName, 'Money', 'New display name is passed to name update action');
       return undefined;
     };
     this.onUpdateColumnParam = (paramId, paramKey) => {
@@ -147,7 +144,10 @@ module('Integration | Component | navi-column-config/metric', function (hooks) {
     };
     await render(TEMPLATE);
 
-    // assert.dom('.navi-column-config-base__column-name-input').hasValue('Revenue', 'Display name of column is shown in the column input');
+    const columnNameInput = '.navi-column-config-base__column-name input';
+    assert
+      .dom(columnNameInput)
+      .hasProperty('placeholder', 'Revenue (USD)', 'Display name of column is shown as a placeholder');
     assert
       .dom('.navi-column-config-item__parameter-trigger')
       .hasText('Dollars (USD)', 'Current parameter is displayed in the dropdown input');
@@ -175,13 +175,14 @@ module('Integration | Component | navi-column-config/metric', function (hooks) {
     );
     await selectChoose('.navi-column-config-item__parameter', 'Dollars (CAD)');
 
-    // assert.dom('.navi-column-config-base__column-name-input').hasValue('Revenue', 'Custom display name is still shown when parameter is changed');
+    assert
+      .dom(columnNameInput)
+      .hasProperty('placeholder', 'Revenue (CAD)', 'Placeholder is updated when parameter is changed');
     assert
       .dom('.navi-column-config-item__parameter-trigger')
       .hasText('Dollars (CAD)', 'Parameter selector shows new parameter value');
 
-    // await fillIn('.navi-column-config-base__column-name-input', 'Money');
-
-    // await triggerKeyEvent('.navi-column-config-base__column-name-input', 'keyup', 13);
+    await fillIn(columnNameInput, 'Money');
+    await triggerKeyEvent(columnNameInput, 'keyup', 13);
   });
 });

--- a/packages/reports/tests/integration/components/navi-column-config/time-dimension-test.js
+++ b/packages/reports/tests/integration/components/navi-column-config/time-dimension-test.js
@@ -9,7 +9,7 @@ const TEMPLATE = hbs`
   <NaviColumnConfig::Base
     @column={{this.column}}
     @cloneColumn={{optional this.cloneColumn}}
-    @toggleColumnFilter={{optional this.toggleColumnFilter}}
+    @onAddFilter={{optional this.onAddFilter}}
     @onRenameColumn={{optional this.onRenameColumn}}
     @onUpdateColumnParam={{optional this.onUpdateColumnParam}}
   />

--- a/packages/reports/tests/integration/components/report-builder-test.js
+++ b/packages/reports/tests/integration/components/report-builder-test.js
@@ -51,6 +51,7 @@ module('Integration | Component | report builder', function (hooks) {
           metricIds: [],
           dimensionIds: [],
           timeDimensionIds: [],
+          requestConstraintIds: []
         }),
       ],
       'bardOne'

--- a/packages/reports/tests/integration/components/report-builder-test.js
+++ b/packages/reports/tests/integration/components/report-builder-test.js
@@ -51,7 +51,7 @@ module('Integration | Component | report builder', function (hooks) {
           metricIds: [],
           dimensionIds: [],
           timeDimensionIds: [],
-          requestConstraintIds: []
+          requestConstraintIds: [],
         }),
       ],
       'bardOne'

--- a/packages/reports/tests/unit/components/filter-builders/time-dimension-test.ts
+++ b/packages/reports/tests/unit/components/filter-builders/time-dimension-test.ts
@@ -42,6 +42,7 @@ module('Unit | Component | filter-builders/time-dimension', function (hooks) {
     const filter = Request.filters.objectAt(0) as TimeDimensionFilterBuilder['args']['filter'];
     const args: TimeDimensionFilterBuilder['args'] = {
       request: Request,
+      isRequired: false,
       filter,
       onUpdateFilter: () => undefined,
     };
@@ -72,6 +73,7 @@ module('Unit | Component | filter-builders/time-dimension', function (hooks) {
     filter.updateParameters({ grain: 'isoWeek' });
     const args: TimeDimensionFilterBuilder['args'] = {
       request: Request,
+      isRequired: false,
       filter,
       onUpdateFilter: () => undefined,
     };

--- a/packages/reports/tests/unit/consumers/request/constraint-test.ts
+++ b/packages/reports/tests/unit/consumers/request/constraint-test.ts
@@ -18,11 +18,11 @@ interface TestContext extends Context {
   metadataService: NaviMetadataService;
 }
 
-module('Unit | Consumer | request constraint', function(hooks) {
+module('Unit | Consumer | request constraint', function (hooks) {
   setupTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(async function(this: TestContext) {
+  hooks.beforeEach(async function (this: TestContext) {
     consumer = this.owner
       .factoryFor('consumer:request/constraint')
       .create({ requestConstrainer: MockConstrainer }) as ConstraintConsumer;
@@ -30,11 +30,11 @@ module('Unit | Consumer | request constraint', function(hooks) {
     await this.metadataService.loadMetadata({ dataSourceName: 'bardOne' });
   });
 
-  test('DID_UPDATE_TABLE', function(assert) {
+  test('DID_UPDATE_TABLE', function (assert) {
     assert.expect(1);
     const mockRoute = ({ modelFor: () => ({ request: 'fakeRequest' }) } as unknown) as Route;
 
-    MockConstrainer.constrain = route => {
+    MockConstrainer.constrain = (route) => {
       assert.deepEqual(route, mockRoute, 'The constrainer service is called after a table update is done');
 
       return route.modelFor(route.routeName) as ReportModel;

--- a/packages/reports/tests/unit/consumers/request/constraint-test.ts
+++ b/packages/reports/tests/unit/consumers/request/constraint-test.ts
@@ -1,0 +1,45 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { TestContext as Context } from 'ember-test-helpers';
+//@ts-ignore
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import Route from '@ember/routing/route';
+import { RequestActions } from 'navi-reports/services/request-action-dispatcher';
+import NaviMetadataService from 'navi-data/services/navi-metadata';
+import ConstraintConsumer from 'navi-reports/consumers/request/constraint';
+import RequestConstrainer from 'navi-reports/services/request-constrainer';
+import ReportModel from 'navi-core/models/report';
+
+let consumer: ConstraintConsumer;
+
+const MockConstrainer: Partial<RequestConstrainer> = {};
+
+interface TestContext extends Context {
+  metadataService: NaviMetadataService;
+}
+
+module('Unit | Consumer | request constraint', function(hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function(this: TestContext) {
+    consumer = this.owner
+      .factoryFor('consumer:request/constraint')
+      .create({ requestConstrainer: MockConstrainer }) as ConstraintConsumer;
+    this.metadataService = this.owner.lookup('service:navi-metadata') as NaviMetadataService;
+    await this.metadataService.loadMetadata({ dataSourceName: 'bardOne' });
+  });
+
+  test('DID_UPDATE_TABLE', function(assert) {
+    assert.expect(1);
+    const mockRoute = ({ modelFor: () => ({ request: 'fakeRequest' }) } as unknown) as Route;
+
+    MockConstrainer.constrain = route => {
+      assert.deepEqual(route, mockRoute, 'The constrainer service is called after a table update is done');
+
+      return route.modelFor(route.routeName) as ReportModel;
+    };
+
+    consumer.send(RequestActions.DID_UPDATE_TABLE, mockRoute);
+  });
+});

--- a/packages/reports/tests/unit/consumers/request/filter-test.js
+++ b/packages/reports/tests/unit/consumers/request/filter-test.js
@@ -27,37 +27,7 @@ module('Unit | Consumer | request filter', function (hooks) {
     await this.metadataService.loadMetadata({ dataSourceName: 'bardOne' });
   });
 
-  test('TOGGLE_DIMENSION_FILTER', function (assert) {
-    assert.expect(4);
-
-    const filter = { type: 'dimension', columnMetadata: 'age' };
-    const modelFor = () => ({ request: { filters: [filter] } });
-
-    consumer.send(RequestActions.TOGGLE_DIMENSION_FILTER, { modelFor }, 'age');
-    assert.deepEqual(
-      dispatchedActions,
-      [RequestActions.REMOVE_FILTER],
-      'REMOVE_FILTER is dispatched when the filter exists'
-    );
-    assert.deepEqual(dispatchedActionArgs, [filter], 'REMOVE_FILTER is dispatched with the correct filter');
-
-    dispatchedActions.length = 0;
-    dispatchedActionArgs.length = 0;
-
-    consumer.send(RequestActions.TOGGLE_DIMENSION_FILTER, { modelFor }, 'browser');
-    assert.deepEqual(
-      dispatchedActions,
-      [RequestActions.ADD_DIMENSION_FILTER],
-      'ADD_DIMENSION_FILTER is dispatched when the filter does not exist'
-    );
-    assert.deepEqual(
-      dispatchedActionArgs,
-      ['browser'],
-      'ADD_DIMENSION_FILTER is dispatched with the correct dimension metadata model'
-    );
-  });
-
-  test('ADD_DIMENSION_FILTER', function (assert) {
+  test('ADD_DIMENSION_FILTER', function(assert) {
     assert.expect(2);
 
     const dimensionMetadataModel = this.metadataService.getById('dimension', 'age', 'bardOne');
@@ -97,8 +67,8 @@ module('Unit | Consumer | request filter', function (hooks) {
               parameters: {
                 grain: 'day',
               },
-              operator: 'gte',
-              values: [],
+              operator: 'bet',
+              values: ['P1D', 'current'],
             },
             'Correct default operator is added for the metadata type'
           );

--- a/packages/reports/tests/unit/consumers/request/filter-test.js
+++ b/packages/reports/tests/unit/consumers/request/filter-test.js
@@ -27,7 +27,7 @@ module('Unit | Consumer | request filter', function (hooks) {
     await this.metadataService.loadMetadata({ dataSourceName: 'bardOne' });
   });
 
-  test('ADD_DIMENSION_FILTER', function(assert) {
+  test('ADD_DIMENSION_FILTER', function (assert) {
     assert.expect(2);
 
     const dimensionMetadataModel = this.metadataService.getById('dimension', 'age', 'bardOne');

--- a/packages/reports/tests/unit/services/request-constrainer-test.ts
+++ b/packages/reports/tests/unit/services/request-constrainer-test.ts
@@ -1,0 +1,215 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import RequestConstrainerService, { TemplateDispatcherAction } from 'navi-reports/services/request-constrainer';
+//@ts-ignore
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import RequestFragment from 'navi-core/models/bard-request-v2/request';
+import { RequestConstraintMetadata } from 'navi-data/models/metadata/request-constraint';
+import { RequestV2 } from 'navi-data/adapters/facts/interface';
+import ColumnFragment from 'navi-core/models/bard-request-v2/fragments/column';
+import NaviMetadataService from 'navi-data/services/navi-metadata';
+import MetadataModelRegistry from 'navi-data/models/metadata/registry';
+import Route from '@ember/routing/route';
+import { mapValues } from 'lodash-es';
+import { MessageOptions } from 'navi-core/services/interfaces/navi-notifications';
+
+let RequestConstrainer: RequestConstrainerService;
+
+type Constraint = RequestConstraintMetadata['constraint'];
+function makeConstraint(property: Constraint['property'], matches: Constraint['matches'], isSatisfied: boolean) {
+  return {
+    type: 'existence',
+    description: `Constraint requiring that ${property} includes a ${matches.field} ${matches.type}`,
+    constraint: {
+      property,
+      matches,
+    },
+    isSatisfied() {
+      return isSatisfied;
+    },
+  };
+}
+
+function fakeRequest({
+  columns = [],
+  filters = [],
+  requestConstraints = [],
+}: {
+  columns?: RequestV2['columns'];
+  filters?: RequestV2['filters'];
+  requestConstraints?: ReturnType<typeof makeConstraint>[];
+}): RequestFragment {
+  const request = ({
+    columns,
+    filters,
+    sorts: [],
+    dataSource: 'dataSource',
+    tableMetadata: {
+      requestConstraints,
+    },
+    serialize() {
+      return request;
+    },
+  } as unknown) as RequestFragment;
+
+  return request;
+}
+
+function serializeConstraints(constraints: ReturnType<RequestConstrainerService['buildConstraints']>) {
+  return constraints.map((dispatcherArgs) =>
+    dispatcherArgs.map((arg) => {
+      if (typeof arg?.serialize === 'function') {
+        const serialized = arg.serialize();
+        if (arg instanceof ColumnFragment) {
+          serialized.cid = `cid_${arg.canonicalName}`;
+        }
+        return serialized;
+      }
+      return arg;
+    })
+  );
+}
+
+module('Unit | Service | request-constrainer', function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function () {
+    RequestConstrainer = this.owner.lookup('service:request-constrainer');
+    this.owner.register(
+      'service:navi-metadata',
+      class extends NaviMetadataService {
+        getById<K extends keyof MetadataModelRegistry>(type: string, field: string, _dataSourceName: string) {
+          return ({
+            getDefaultParameters: () => ({}),
+            serialize() {
+              return { type, field, mockMeta: true };
+            },
+          } as unknown) as MetadataModelRegistry[K];
+        }
+      }
+    );
+  });
+
+  test('buildConstraints', async function (assert) {
+    const request = fakeRequest({
+      requestConstraints: [
+        makeConstraint('filters', { type: 'timeDimension', field: '1' }, false),
+        makeConstraint('filters', { type: 'dimension', field: '2' }, false),
+        makeConstraint('filters', { type: 'dimension', field: '3' }, true),
+        makeConstraint('columns', { type: 'metric', field: '4' }, false),
+        makeConstraint('columns', { type: 'timeDimension', field: '5' }, true),
+      ],
+    });
+
+    assert.deepEqual(
+      serializeConstraints(RequestConstrainer.buildConstraints(request)),
+      [
+        ['addFilter', { alias: null, cid: 'cid_1', field: '1', parameters: {}, type: 'timeDimension' }],
+        ['addFilter', { alias: null, cid: 'cid_2', field: '2', parameters: {}, type: 'dimension' }],
+        ['addColumnWithParams', { field: '4', mockMeta: true, type: 'metric' }],
+      ],
+      'builds dispatcher arguments for constraints that are not satisfied'
+    );
+  });
+
+  test('constrain', async function (assert) {
+    assert.expect(9);
+    const request = fakeRequest({
+      filters: [{ type: 'metric', field: '4', parameters: {}, operator: 'in', values: [] }],
+      columns: [{ type: 'timeDimension', field: '8', parameters: {} }],
+      requestConstraints: [
+        makeConstraint('filters', { type: 'timeDimension', field: '1' }, false),
+        makeConstraint('filters', { type: 'dimension', field: '2' }, false),
+        makeConstraint('filters', { type: 'metric', field: '3' }, true),
+        makeConstraint('filters', { type: 'metric', field: '4' }, false),
+        makeConstraint('columns', { type: 'metric', field: '5' }, false),
+        makeConstraint('columns', { type: 'timeDimension', field: '6' }, true),
+        makeConstraint('columns', { type: 'dimension', field: '7' }, false),
+        makeConstraint('columns', { type: 'timeDimension', field: '8' }, false),
+      ],
+    });
+
+    const fakeRoute = ({
+      modelFor: () => ({ request, title: 'Fake Report' }),
+    } as unknown) as Route;
+
+    RequestConstrainer.naviNotifications.add = ({ title, style, context }: MessageOptions) => {
+      assert.deepEqual(style, 'warning', 'A warning is issued when constraints are not satisfied');
+      assert.deepEqual(
+        title,
+        'The following requirements are not satisfied',
+        'The warning says which constraints could not be satisfied'
+      );
+      assert.deepEqual(
+        context,
+        'Constraint requiring that filters includes a 2 dimension; Constraint requiring that columns includes a 7 dimension',
+        'The failed constraints are passed as the context'
+      );
+    };
+
+    let actionNum = 0;
+    let expectedActions = [
+      ['addFilter', fakeRoute, { alias: null, cid: 'cid_1', field: '1', parameters: {}, type: 'timeDimension' }],
+      ['addFilter', fakeRoute, { alias: null, cid: 'cid_2', field: '2', parameters: {}, type: 'dimension' }],
+      ['addFilter', fakeRoute, { alias: null, cid: 'cid_4', field: '4', parameters: {}, type: 'metric' }],
+      ['addColumnWithParams', fakeRoute, { field: '5', mockMeta: true, type: 'metric' }],
+      ['addColumnWithParams', fakeRoute, { field: '7', mockMeta: true, type: 'dimension' }],
+      ['addColumnWithParams', fakeRoute, { field: '8', mockMeta: true, type: 'timeDimension' }],
+    ];
+    RequestConstrainer.updateReportActionDispatcher.dispatch = (...args: TemplateDispatcherAction) => {
+      const [serialized] = serializeConstraints([args]);
+      assert.deepEqual(serialized, expectedActions[actionNum++], 'The expected actions are passed in');
+      const fieldNum = Number(serialized[2].field);
+      if (fieldNum !== 2 && fieldNum !== 7) {
+        request.tableMetadata!.requestConstraints[fieldNum - 1].isSatisfied = () => true;
+      }
+    };
+
+    RequestConstrainer.constrain(fakeRoute);
+  });
+
+  test('getConstrainedProperties', async function (assert) {
+    const requiredFilters: RequestV2['filters'] = [
+      { type: 'timeDimension', field: '1', parameters: {}, operator: 'bet', values: [] },
+      { type: 'dimension', field: '2', parameters: {}, operator: 'in', values: [] },
+      { type: 'dimension', field: '3', parameters: {}, operator: 'isnull', values: [true] },
+    ];
+    const requiredColumns: RequestV2['columns'] = [
+      { type: 'metric', field: '4', parameters: {} },
+      { type: 'timeDimension', field: '5', parameters: {} },
+    ];
+    const request = fakeRequest({
+      filters: [
+        { type: 'timeDimension', field: 'skipped', parameters: {}, operator: 'bet', values: [] },
+        { type: 'metric', field: 'skipped', parameters: {}, operator: 'bet', values: [] },
+        ...requiredFilters,
+        { type: 'dimension', field: 'skipped', parameters: {}, operator: 'bet', values: [] },
+      ],
+      columns: [
+        { type: 'timeDimension', field: 'skipped', parameters: {} },
+        { type: 'metric', field: 'skipped', parameters: {} },
+        ...requiredColumns,
+        { type: 'dimension', field: 'skipped', parameters: {} },
+      ],
+      requestConstraints: [
+        makeConstraint('filters', { type: 'timeDimension', field: '1' }, false),
+        makeConstraint('filters', { type: 'dimension', field: '2' }, false),
+        makeConstraint('filters', { type: 'dimension', field: '3' }, true),
+        makeConstraint('columns', { type: 'metric', field: '4' }, false),
+        makeConstraint('columns', { type: 'timeDimension', field: '5' }, true),
+      ],
+    });
+
+    assert.deepEqual(
+      mapValues(RequestConstrainer.getConstrainedProperties(request), (p) => (p ? [...p] : [])),
+      {
+        //@ts-expect-error
+        filters: requiredFilters,
+        //@ts-expect-error
+        columns: requiredColumns,
+      },
+      'Returns the list of filters and columns that match the given request constraints'
+    );
+  });
+});

--- a/packages/reports/tests/unit/services/request-constrainer-test.ts
+++ b/packages/reports/tests/unit/services/request-constrainer-test.ts
@@ -143,7 +143,7 @@ module('Unit | Service | request-constrainer', function (hooks) {
       );
       assert.deepEqual(
         context,
-        'Constraint requiring that filters includes a 2 dimension; Constraint requiring that columns includes a 7 dimension',
+        '1) Constraint requiring that filters includes a 2 dimension 2) Constraint requiring that columns includes a 7 dimension',
         'The failed constraints are passed as the context'
       );
     };


### PR DESCRIPTION
Resolves #997 

## Description
Adds support for basic metadata driven constraints at the table level such as specifying a date time filter for fili tables
```js
{
    property: 'filters',
    matches: {
      type: 'timeDimension',
      field: 'tableName.dateTime'
    }
}
```

or a date time column for fili tables that do not support an all grain

```js
{
    property: 'columns',
    matches: {
      type: 'timeDimension',
      field: 'tableName.dateTime'
    }
}
```

## Proposed Changes

- metadata drive table constraints
- basic constraint solver that adds missing filters/columns
- consumer to listen for switching table/new report events and re-add constraints if needed
- metric/dimension selector and column config now always add new filters instead of toggling

## Screenshots
![required filters/columns](https://user-images.githubusercontent.com/12093492/108455717-5a131d00-7234-11eb-88da-13632d309888.png)


## License

I confirm that this contribution is made under an MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
