### PR TITLE
Update: Add support for multiple time grains in elide

### DIFF
--- a/packages/data/addon/adapters/facts/bard.ts
+++ b/packages/data/addon/adapters/facts/bard.ts
@@ -19,6 +19,7 @@ import NaviFactAdapter, {
   AsyncQueryResponse,
   Column,
   Sort,
+  FactAdapterError,
 } from './interface';
 import { omit } from 'lodash-es';
 import NaviMetadataService from 'navi-data/services/navi-metadata';
@@ -29,9 +30,6 @@ import moment from 'moment';
 import config from 'ember-get-config';
 
 export type Query = RequestOptions & Dict<string | number | boolean>;
-export class FactAdapterError extends Error {
-  name = 'FactAdapterError';
-}
 
 /**
  * @param column - dimension column

--- a/packages/data/addon/adapters/facts/elide.ts
+++ b/packages/data/addon/adapters/facts/elide.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2021, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import EmberObject from '@ember/object';
@@ -42,11 +42,9 @@ export function getElideField(fieldName: string, parameters: Parameters = {}, al
   const parts = fieldName.split('.');
   const field = parts[parts.length - 1];
 
-  // TODO: Support multiple parameters serialization
-  assert('There is at most one parameter', Object.keys(parameters).length <= 1);
   const paramsInner = Object.entries(parameters)
     .map(([param, val]) => `${param}:"${val}"`)
-    .join('; ');
+    .join(', ');
   const paramsStr = paramsInner.length > 0 ? `(${paramsInner})` : '';
 
   return `${aliasStr}${field}${paramsStr}`;

--- a/packages/data/addon/adapters/facts/elide.ts
+++ b/packages/data/addon/adapters/facts/elide.ts
@@ -23,16 +23,27 @@ import { task, timeout } from 'ember-concurrency';
 import { v1 } from 'ember-uuid';
 import moment, { Moment } from 'moment';
 import { Grain } from 'navi-data/utils/date';
+import { canonicalizeMetric } from 'navi-data/utils/metric';
 
 const escape = (value: string) => value.replace(/'/g, "\\\\'");
 
 /**
  * Formats elide request field
  */
-export function getElideField(fieldName: string, _parameters: Parameters = {}) {
-  //TODO add parameter support when added to Elide
+export function getElideField(fieldName: string, parameters: Parameters = {}, alias?: string) {
+  const aliasStr = alias ? `${alias}:` : '';
+
   const parts = fieldName.split('.');
-  return parts[parts.length - 1];
+  const field = parts[parts.length - 1];
+
+  // TODO: Support multiple parameters serialization
+  assert('There is at most one parameter', Object.keys(parameters).length <= 1);
+  let paramsInner = Object.entries(parameters)
+    .map(([param, val]) => `${param}:"${val}"`)
+    .join('; ');
+  const paramsStr = paramsInner.length > 0 ? `(${paramsInner})` : '';
+
+  return `${aliasStr}${field}${paramsStr}`;
 }
 
 export default class ElideFactsAdapter extends EmberObject implements NaviFactAdapter {
@@ -78,7 +89,7 @@ export default class ElideFactsAdapter extends EmberObject implements NaviFactAd
     nbet: (f, v) => `${f}=lt=('${v[0]}'),${f}=gt=('${v[1]}')`,
   };
 
-  private buildFilterStr(filters: Filter[]): string {
+  private buildFilterStr(filters: Filter[], canonicalToAlias: Record<string, string>): string {
     const filterStrings = filters.map((filter) => {
       const { field, parameters, operator, values, type } = filter;
 
@@ -87,7 +98,10 @@ export default class ElideFactsAdapter extends EmberObject implements NaviFactAd
         return null;
       }
 
-      const fieldStr = getElideField(field, parameters);
+      // TODO: Parameters cannot be specified in filters yet
+      const elideField = getElideField(field, {});
+      const canonicalName = canonicalizeMetric({ metric: field, parameters });
+      const fieldStr = canonicalToAlias[canonicalName] || elideField;
       let filterVals = values.map((v) => escape(`${v}`));
 
       if (type === 'timeDimension' && operator !== 'isnull') {
@@ -116,14 +130,36 @@ export default class ElideFactsAdapter extends EmberObject implements NaviFactAd
   private dataQueryFromRequest(request: RequestV2): string {
     const args = [];
     const { table, columns, sorts, limit, filters } = request;
-    const columnsStr = columns.map((col) => getElideField(col.field, col.parameters)).join(' ');
+    const columnCanonicalToAlias = columns.reduce((canonicalToAlias: Record<string, string>, column, idx) => {
+      const canonicalName = canonicalizeMetric({ metric: column.field, parameters: column.parameters });
+      // Use 'colX' as alias so that filters/sorts can reference the alias
+      canonicalToAlias[canonicalName] = `col${idx}`;
+      return canonicalToAlias;
+    }, {});
+    const columnsStr = columns
+      .map(({ type, field, parameters }) => {
+        const alias = columnCanonicalToAlias[canonicalizeMetric({ metric: field, parameters })];
+        if (type === 'timeDimension') {
+          // The elide time grain is uppercase (but we serialize to lowercase to use as Grain internally)
+          const grain = parameters.grain?.toUpperCase();
+          parameters = {
+            ...parameters,
+            ...(grain ? { grain } : {}),
+          };
+        }
+        return getElideField(field, parameters, alias);
+      })
+      .join(' ');
 
-    const filterString = this.buildFilterStr(filters);
+    const filterString = this.buildFilterStr(filters, columnCanonicalToAlias);
     filterString.length && args.push(`filter: "${filterString}"`);
 
     const sortStrings = sorts.map((sort) => {
       const { field, parameters, direction } = sort;
-      const column = getElideField(field, parameters);
+      // Parameters cannot be specified in sorts
+      const elideField = getElideField(field, {});
+      const canonicalName = canonicalizeMetric({ metric: field, parameters: parameters });
+      const column = columnCanonicalToAlias[canonicalName] || elideField;
       return `${direction === 'desc' ? '-' : ''}${column}`;
     });
     sortStrings.length && args.push(`sort: "${sortStrings.join(',')}"`);

--- a/packages/data/addon/adapters/facts/interface.ts
+++ b/packages/data/addon/adapters/facts/interface.ts
@@ -115,6 +115,10 @@ export type AsyncQueryResponse = {
   };
 };
 
+export class FactAdapterError extends Error {
+  name = 'FactAdapterError';
+}
+
 export interface AsyncQueryResult {
   httpStatus: number;
   contentLength: number;

--- a/packages/data/addon/serializers/dimensions/elide.ts
+++ b/packages/data/addon/serializers/dimensions/elide.ts
@@ -1,12 +1,11 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2021, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 
 import NaviDimensionSerializer from './interface';
 import NaviDimensionModel from '../../models/navi-dimension';
 import { AsyncQueryResponse } from 'navi-data/adapters/facts/interface';
-import { getElideField } from '../../adapters/facts/elide';
 import EmberObject from '@ember/object';
 import { DimensionColumn } from 'navi-data/models/metadata/dimension';
 import ElideDimensionMetadataModel from 'navi-data/models/metadata/elide/dimension';
@@ -18,15 +17,13 @@ export type ResponseEdge = {
 export default class ElideDimensionSerializer extends EmberObject implements NaviDimensionSerializer {
   normalize(dimension: DimensionColumn, rawPayload?: AsyncQueryResponse): NaviDimensionModel[] {
     const responseStr = rawPayload?.asyncQuery.edges[0].node.result?.responseBody;
-    const { id, tableId } = (dimension.columnMetadata as ElideDimensionMetadataModel).lookupColumn;
-    const match = new RegExp(`${tableId}\\.(.*)`).exec(id); // Remove table id from start of dimension e.g. tableA.dim1 => dim1
-    const dimensionName = match ? match[1] : id;
+    const { tableId } = (dimension.columnMetadata as ElideDimensionMetadataModel).lookupColumn;
 
     if (responseStr) {
       const response = JSON.parse(responseStr);
       return response.data[tableId as string].edges.map((edge: ResponseEdge) =>
         NaviDimensionModel.create({
-          value: edge.node[getElideField(dimensionName, dimension.parameters)],
+          value: edge.node.col0,
           dimensionColumn: dimension,
         })
       );

--- a/packages/data/addon/serializers/facts/bard.ts
+++ b/packages/data/addon/serializers/facts/bard.ts
@@ -12,7 +12,7 @@ import { canonicalizeMetric } from 'navi-data/utils/metric';
 import NaviFactResponse from 'navi-data/models/navi-fact-response';
 import NaviAdapterError, { NaviErrorDetails } from 'navi-data/errors/navi-adapter-error';
 import { AjaxError } from 'ember-ajax/errors';
-import { FactAdapterError } from 'navi-data/adapters/facts/bard';
+import { FactAdapterError } from 'navi-data/adapters/facts/interface';
 
 type BardError = {
   description: string;

--- a/packages/data/addon/serializers/facts/elide.ts
+++ b/packages/data/addon/serializers/facts/elide.ts
@@ -7,7 +7,7 @@
 
 import EmberObject from '@ember/object';
 import NaviFactSerializer from './interface';
-import { AsyncQueryResponse, RequestV2 } from 'navi-data/adapters/facts/interface';
+import { AsyncQueryResponse, FactAdapterError, RequestV2 } from 'navi-data/adapters/facts/interface';
 import { canonicalizeMetric } from 'navi-data/utils/metric';
 import NaviFactResponse from 'navi-data/models/navi-fact-response';
 import NaviFactError, { NaviErrorDetails } from 'navi-data/errors/navi-adapter-error';
@@ -73,6 +73,9 @@ export default class ElideFactsSerializer extends EmberObject implements NaviFac
     }
     if (isApolloError(payload)) {
       errors = (payload.errors || []).map((e) => ({ detail: e.message }));
+    }
+    if (payload instanceof FactAdapterError) {
+      errors = [{ title: payload.name, detail: payload.message }];
     }
     return new NaviFactError('Elide Request Failed', errors, payload);
   }

--- a/packages/data/addon/serializers/facts/elide.ts
+++ b/packages/data/addon/serializers/facts/elide.ts
@@ -8,7 +8,6 @@
 import EmberObject from '@ember/object';
 import NaviFactSerializer from './interface';
 import { AsyncQueryResponse, RequestV2 } from 'navi-data/adapters/facts/interface';
-import { getElideField } from 'navi-data/adapters/facts/elide';
 import { canonicalizeMetric } from 'navi-data/utils/metric';
 import NaviFactResponse from 'navi-data/models/navi-fact-response';
 import NaviFactError, { NaviErrorDetails } from 'navi-data/errors/navi-adapter-error';
@@ -32,8 +31,7 @@ export default class ElideFactsSerializer extends EmberObject implements NaviFac
   private processResponse(payload: string, request: RequestV2): NaviFactResponse {
     const response = JSON.parse(payload) as ExecutionResult;
     const { table } = request;
-    // TODO revisit when Elide adds parameter support
-    const elideFields = request.columns.map(({ field, parameters }) => getElideField(field, parameters));
+    const elideFields = request.columns.map((_c, idx) => `col${idx}`);
     const normalizedFields = request.columns.map(({ field: metric, parameters }) =>
       // TODO rename with generic canonicalizeColumn
       canonicalizeMetric({ metric, parameters })

--- a/packages/data/tests/unit/adapters/facts/elide-test.ts
+++ b/packages/data/tests/unit/adapters/facts/elide-test.ts
@@ -71,7 +71,7 @@ module('Unit | Adapter | facts/elide', function (hooks) {
     assert.equal(
       getElideField('foo', { bar: 'baz', bang: 'boom' }),
       'foo(bar:"baz", bang:"boom")',
-      'Field with multiple parameters is not supported'
+      'Field with multiple parameters is formatted correctly'
     );
     assert.equal(getElideField('foo'), 'foo', 'Name is returned for field with no parameters');
   });

--- a/packages/data/tests/unit/adapters/facts/elide-test.ts
+++ b/packages/data/tests/unit/adapters/facts/elide-test.ts
@@ -68,9 +68,9 @@ module('Unit | Adapter | facts/elide', function (hooks) {
 
   test('getElideField', function (assert) {
     assert.equal(getElideField('foo', { bar: 'baz' }), 'foo(bar:"baz")', 'Field with parameter is not supported');
-    assert.throws(
-      () => getElideField('foo', { bar: 'baz', bang: 'boom' }),
-      /There is at most one parameter/,
+    assert.equal(
+      getElideField('foo', { bar: 'baz', bang: 'boom' }),
+      'foo(bar:"baz", bang:"boom")',
       'Field with multiple parameters is not supported'
     );
     assert.equal(getElideField('foo'), 'foo', 'Name is returned for field with no parameters');

--- a/packages/data/tests/unit/serializers/dimensions/elide-test.ts
+++ b/packages/data/tests/unit/serializers/dimensions/elide-test.ts
@@ -35,14 +35,14 @@ module('Unit | Serializer | Dimensions | Elide', function (hooks) {
           {
             node: {
               id: 'c7d2fe70-b63f-11ea-b45b-bf754c72eca6',
-              query: '"{ "query": "{ tableA { edges { node { dimension1 } } } } " }',
+              query: '"{ "query": "{ tableA { edges { node { col0:dimension1 } } } } " }',
               status: QueryStatus.COMPLETE,
               result: {
                 contentLength: 129,
                 httpStatus: 200,
                 recordCount: 3,
                 responseBody:
-                  '{"data":{"table0":{"edges":[{"node":{"dimension1":"foo"}},{"node":{"dimension1":"bar"}},{"node":{"dimension1":"baz"}}]}}}',
+                  '{"data":{"table0":{"edges":[{"node":{"col0":"foo"}},{"node":{"col0":"bar"}},{"node":{"col0":"baz"}}]}}}',
               },
             },
           },
@@ -76,13 +76,13 @@ module('Unit | Serializer | Dimensions | Elide', function (hooks) {
           {
             node: {
               id: 'c7d2fe70-b63f-11ea-b45b-bf754c72eca6',
-              query: `"{ "query": "{ ${lookupTable} { edges { node { ${lookupField} } } } } " }`,
+              query: `"{ "query": "{ ${lookupTable} { edges { node { col0:${lookupField} } } } } " }`,
               status: QueryStatus.COMPLETE,
               result: {
                 contentLength: 129,
                 httpStatus: 200,
                 recordCount: 3,
-                responseBody: `{"data":{"${lookupTable}":{"edges":[{"node":{"${lookupField}":"foo"}},{"node":{"${lookupField}":"bar"}},{"node":{"${lookupField}":"baz"}}]}}}`,
+                responseBody: `{"data":{"${lookupTable}":{"edges":[{"node":{"col0":"foo"}},{"node":{"col0":"bar"}},{"node":{"col0":"baz"}}]}}}`,
               },
             },
           },

--- a/packages/data/tests/unit/serializers/facts/elide-test.ts
+++ b/packages/data/tests/unit/serializers/facts/elide-test.ts
@@ -11,14 +11,14 @@ const Payload: AsyncQueryResponse = {
       {
         node: {
           id: 'c7d2fe70-b63f-11ea-b45b-bf754c72eca6',
-          query: '"{ "query": "{ tableA { edges { node { datestamp user_count } } } } " }',
+          query: '"{ "query": "{ tableA { edges { node { col0:datestamp col1:user_count } } } } " }',
           status: QueryStatus.COMPLETE,
           result: {
             contentLength: 129,
             httpStatus: 200,
             recordCount: 2,
             responseBody:
-              '{"data":{"tableA":{"edges":[{"node":{"datestamp":"202003", "userCount":10}},{"node":{"datestamp":"202004", "userCount":20}}]}}}',
+              '{"data":{"tableA":{"edges":[{"node":{"col0":"202003", "col1":10}},{"node":{"col0":"202004", "col1":20}}]}}}',
           },
         },
       },

--- a/packages/reports/addon/consumers/request/filter.ts
+++ b/packages/reports/addon/consumers/request/filter.ts
@@ -97,7 +97,7 @@ export default class FilterConsumer extends ActionConsumer {
         values: [],
       };
       let values;
-      if (dimensionMetadataModel.metadataType === 'timeDimension') {
+      if (dimensionMetadataModel.metadataType === 'timeDimension' && defaultOperator === 'bet') {
         values = valuesForOperator(filter, filter.parameters.grain as Grain, OPERATORS.lookback);
       }
 

--- a/packages/reports/tests/integration/components/common-actions/get-api-test.js
+++ b/packages/reports/tests/integration/components/common-actions/get-api-test.js
@@ -99,7 +99,7 @@ module('Integration | Component | common actions/get api', function (hooks) {
     assert
       .dom('.get-api__api-input')
       .hasValue(
-        '{"query":"{ tableA { edges { node { datestamp userCount } } } }"}',
+        '{"query":"{ tableA { edges { node { col0:datestamp col1:userCount } } } }"}',
         'Modal input box has link to the current page'
       );
 

--- a/packages/webservice/app/src/main/resources/demo-configs/models/tables/DemoTables.hjson
+++ b/packages/webservice/app/src/main/resources/demo-configs/models/tables/DemoTables.hjson
@@ -58,6 +58,12 @@
             {
                type: DAY
             }
+            {
+               type: YEAR
+               sql :  '''
+               PARSEDATETIME(YEAR({{}}), 'YYYY')
+               '''
+            }
           ]
         }
         {


### PR DESCRIPTION
Resolves #1258 

## Description
Elide added support for multiple time grains on timeDimensions

## Proposed Changes
- Use alias for each requested column and use it for applicable sorts/filters
- single parameter support for elide which allows requesting specific grains of a timeDimension
- added example of day/year timegrain for netflix dataset

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
