### PR TITLE
Update: Support since/before operator in fili

### DIFF
--- a/packages/data/addon/adapters/facts/bard.ts
+++ b/packages/data/addon/adapters/facts/bard.ts
@@ -162,6 +162,9 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
       }
     } else if (timeFilter.operator === 'gte') {
       [start] = timeFilter.values as string[];
+      if (!moment.utc(start).isValid()) {
+        throw new FactAdapterError(`Since operator only supports datetimes, '${start}' is invalid`);
+      }
       end = moment.utc('9999-12-31').startOf(filterGrain).toISOString();
     } else if (timeFilter.operator === 'lte') {
       start = moment
@@ -169,6 +172,9 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
         .startOf(filterGrain)
         .toISOString();
       [end] = timeFilter.values as string[];
+      if (!moment.utc(end).isValid()) {
+        throw new FactAdapterError(`Before operator only supports datetimes, '${end}' is invalid`);
+      }
     } else {
       assert(`Time Dimension filter operator ${timeFilter.operator} is not supported`);
     }

--- a/packages/reports/tests/acceptance/fili-datasource-test.ts
+++ b/packages/reports/tests/acceptance/fili-datasource-test.ts
@@ -126,4 +126,25 @@ module('Acceptance | fili datasource', function (hooks) {
       .hasText('Date Time (day)', 'A date time column exists after switching to a table with no all grain');
     assert.dom('.navi-column-config-item__remove-icon').isDisabled('The date time column cannot be removed');
   });
+
+  test('Fili supports since and before operators', async function (assert) {
+    assert.expect(2);
+
+    await visit('/reports/new');
+
+    await clickItem('dimension', 'Date Time');
+    await selectChoose('.navi-column-config-item__parameter', 'Year');
+
+    await selectChoose('.filter-builder__operator-trigger', 'Before');
+    await click('.navi-report__run-btn');
+    assert.dom('.table-row').hasText('2013', 'Results are fetched for Before operator');
+
+    await selectChoose('.filter-builder__operator-trigger', 'Since');
+    await click('.dropdown-date-picker__trigger');
+    await click('.ember-power-calendar-selector-nav-control--previous');
+    await click('[data-date="2015"]');
+
+    await click('.navi-report__run-btn');
+    assert.dom('.table-row').hasText('2015', 'Results are fetched for Since operator');
+  });
 });

--- a/packages/reports/tests/unit/components/filter-builders/time-dimension-test.ts
+++ b/packages/reports/tests/unit/components/filter-builders/time-dimension-test.ts
@@ -292,7 +292,6 @@ module('Unit | Component | filter-builders/time-dimension', function (hooks) {
       'in translates P1D lookback to concrete'
     );
 
-    debugger;
     filter.values = ['P1W', '2018-12-31'];
     filter.parameters.grain = 'isoWeek';
     assert.deepEqual(


### PR DESCRIPTION
Resolves #1260

## Description
Add support for since/before operators in fili by using far past (or dataEpoch) and distant future as bounds

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
